### PR TITLE
(Fix) Keys ballot type to transaction: add/remove/swap fix

### DIFF
--- a/src/components/NewBallot.jsx
+++ b/src/components/NewBallot.jsx
@@ -102,7 +102,7 @@ export class NewBallot extends React.Component {
       ballotStore.ballotKeys.affectedKey, 
       ballotStore.ballotKeys.keyType, 
       ballotStore.ballotKeys.miningKey,
-      ballotStore.ballotType,
+      ballotStore.ballotKeys.keysBallotType,
       contractsStore.votingKey
     ];
     console.log(inputToMethod)


### PR DESCRIPTION
Closes #43 

**Problem**: Key ballot type is set to 1 for every option: add/remove/swap
**Solution**: The wrong variable replaced with the right one