### PR TITLE
(Fix) Cannot update during an existing state transition warning fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,15 +10,11 @@ import { inject, observer } from 'mobx-react';
 @observer
 class App extends Component {
   onBallotsRender = () => {
-    const { commonStore } = this.props;
-    commonStore.isActiveFilter = false;
-    return <Ballots/>;
+    return <Ballots isActiveFilter={false}/>;
   }
 
   onActiveBallotsRender = () => {
-    const { commonStore } = this.props;
-    commonStore.isActiveFilter = true;
-    return <Ballots/>;
+    return <Ballots isActiveFilter={true}/>;
   }
 
   onNewBallotRender = () => {

--- a/src/components/Ballots.jsx
+++ b/src/components/Ballots.jsx
@@ -6,8 +6,8 @@ import "babel-polyfill";
 @observer
 export class Ballots extends React.Component {
   componentWillMount () {
-  	const { commonStore } = this.props;
-  	commonStore.isActiveFilter = this.props.isActiveFilter;
+    const { commonStore } = this.props;
+    commonStore.isActiveFilter = this.props.isActiveFilter;
   }
 
   render () {

--- a/src/components/Ballots.jsx
+++ b/src/components/Ballots.jsx
@@ -2,9 +2,14 @@ import React from 'react';
 import { inject, observer } from "mobx-react";
 import "babel-polyfill";
 
-@inject("ballotsStore")
+@inject("commonStore", "ballotsStore")
 @observer
 export class Ballots extends React.Component {
+  componentWillMount () {
+  	const { commonStore } = this.props;
+  	commonStore.isActiveFilter = this.props.isActiveFilter;
+  }
+
   render () {
     const { ballotsStore } = this.props;
     return (

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,6 @@ class AppMainRouter extends Component {
       await contractsStore.setVotingToChangeMinThreshold(web3Config);
       await contractsStore.setVotingToChangeProxy(web3Config);
       await contractsStore.setValidatorMetadata(web3Config);
-      contractsStore.setWeb3Instance(web3Config);
       contractsStore.getValidatorsLength();
       contractsStore.getKeysBallotThreshold();
       contractsStore.getMinThresholdBallotThreshold();

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ class AppMainRouter extends Component {
       await contractsStore.setVotingToChangeMinThreshold(web3Config);
       await contractsStore.setVotingToChangeProxy(web3Config);
       await contractsStore.setValidatorMetadata(web3Config);
+      contractsStore.setWeb3Instance(web3Config);
       contractsStore.getValidatorsLength();
       contractsStore.getKeysBallotThreshold();
       contractsStore.getMinThresholdBallotThreshold();

--- a/src/stores/ContractsStore.js
+++ b/src/stores/ContractsStore.js
@@ -10,7 +10,6 @@ import ValidatorMetadata from '../contracts/ValidatorMetadata.contract'
 import ballotStore from './BallotStore'
 import ballotsStore from './BallotsStore'
 import commonStore from './CommonStore'
-import getWeb3 from '../getWeb3';
 import { BallotKeysCard } from "../components/BallotKeysCard";
 import { BallotMinThresholdCard } from "../components/BallotMinThresholdCard";
 import { BallotProxyCard } from "../components/BallotProxyCard";
@@ -41,9 +40,6 @@ class ContractsStore {
 		this.activeKeysBallotsIDs = [];
 		this.validatorsMetadata = [];
 		this.validatorLimits = {keys: null, minThreshold: null, proxy: null};
-		getWeb3().then(async (web3Config) => {
-			contractsStore.setWeb3Instance(web3Config);
-		})
 	}
 
 	@computed get isValidVotingKey() {


### PR DESCRIPTION
Closes #46 

**Problem**: 
When switching to active ballots:
```
Warning: Cannot update during an existing state transition (such as within `render` or another component's constructor). Render methods should be a pure function of props and state; constructor side-effects are an anti-pattern, but can be moved to `componentWillMount`.
```
**Solution**: Move state update from rendering to `componentWillMount`.