### PR TITLE
(Fix) invalid/duplicate ids for end date field and mining key field

### DIFF
--- a/src/components/BallotKeysMetadata.jsx
+++ b/src/components/BallotKeysMetadata.jsx
@@ -26,10 +26,10 @@ export class BallotKeysMetadata extends React.Component {
           </div>
           <div className="right">
             <div className="form-el">
-              <label htmlFor="key">Mining Key</label>
+              <label htmlFor="mining-key">Mining Key</label>
               <Select.Creatable
                 name="form-field-name"
-                id="key"
+                id="mining-key"
                 value={ballotStore.ballotKeys.miningKey} 
                 onChange={ballotStore.setMiningKey} 
                 options={options}

--- a/src/components/BallotKeysMetadata.jsx
+++ b/src/components/BallotKeysMetadata.jsx
@@ -41,8 +41,8 @@ export class BallotKeysMetadata extends React.Component {
           </div>
           <div className="left">
             <div className="form-el">
-              <label htmlFor="key">Ballot End</label>
-              <input type="datetime-local" id="key" 
+              <label htmlFor="datetime-local">Ballot End</label>
+              <input type="datetime-local" id="datetime-local"
                 value={ballotStore.endTime}
                 min={ballotStore.endTime}
                 onChange={e => ballotStore.changeBallotMetadata(e, "endTime")} 

--- a/src/components/BallotMinThresholdMetadata.jsx
+++ b/src/components/BallotMinThresholdMetadata.jsx
@@ -23,8 +23,8 @@ export class BallotMinThresholdMetadata extends React.Component {
           </div>
           <div className="right">
             <div className="form-el">
-              <label htmlFor="key">Ballot End</label>
-              <input type="datetime-local" id="key" 
+              <label htmlFor="datetime-local">Ballot End</label>
+              <input type="datetime-local" id="datetime-local" 
                 value={ballotStore.endTime} 
                 onChange={e => ballotStore.changeBallotMetadata(e, "endTime")} 
               />

--- a/src/components/BallotProxyMetadata.jsx
+++ b/src/components/BallotProxyMetadata.jsx
@@ -45,8 +45,8 @@ export class BallotProxyMetadata extends React.Component {
           </div>
           <div className="left">
             <div className="form-el">
-              <label htmlFor="key">Ballot End</label>
-              <input type="datetime-local" id="key" 
+              <label htmlFor="datetime-local">Ballot End</label>
+              <input type="datetime-local" id="datetime-local" 
                 value={ballotStore.endTime} 
                 onChange={e => ballotStore.changeBallotMetadata(e, "endTime")} 
               />


### PR DESCRIPTION
Ballot end date and mining key elements have the same `id = key`.