### PR TITLE
(Fix) Don't precache index.html

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -321,7 +321,7 @@ module.exports = {
       // https://github.com/facebookincubator/create-react-app/issues/2237#issuecomment-302693219
       navigateFallbackWhitelist: [/^(?!\/__).*/],
       // Don't precache sourcemaps (they're large) and build asset manifest:
-      staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/],
+      staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/, /index\.html$/],
     }),
     // Moment.js is an extremely popular library that bundles large locale files
     // by default due to how Webpack interprets its code. This is a practical


### PR DESCRIPTION
- (Mandatory) Description
A small fix to not to cache index.html to make DApp workable in Trust Wallet browser, Android version. Relates to https://github.com/poanetwork/poa-dapps-voting/issues/122 and https://github.com/poanetwork/poa-dapps-voting/issues/141.

- (Mandatory) What is it: (Fix), (Feature) or (Refactor)
(Fix)