### PR TITLE
(Fix) Checking transaction status when voting or finalizing

### DIFF
--- a/src/components/BallotCard.jsx
+++ b/src/components/BallotCard.jsx
@@ -181,11 +181,16 @@ export class BallotCard extends React.Component {
             return;
         }
         this.getContract(contractsStore, votingType).vote(id, choice, contractsStore.votingKey)
-        .on("receipt", () => {
+        .on("receipt", (tx) => {
             commonStore.hideLoading();
-            swal("Congratulations!", messages.VOTED_SUCCESS_MSG, "success").then((result) => {
-                push(`${commonStore.rootPath}`);
-            });
+            if (tx.status === true || tx.status === '0x1') {
+                swal("Congratulations!", messages.VOTED_SUCCESS_MSG, "success").then((result) => {
+                    push(`${commonStore.rootPath}`);
+                });
+            } else {
+                swal("Warning!", messages.VOTE_FAILED_TX, "warning").then((result) => {
+                });
+            }
         })
         .on("error", (e) => {
             commonStore.hideLoading();
@@ -225,11 +230,16 @@ export class BallotCard extends React.Component {
             return;
         }
         this.getContract(contractsStore, votingType).finalize(id, contractsStore.votingKey)
-        .on("receipt", () => {
+        .on("receipt", (tx) => {
             commonStore.hideLoading();
-            swal("Congratulations!", messages.FINALIZED_SUCCESS_MSG, "success").then((result) => {
-                push(`${commonStore.rootPath}`);
-            });
+            if (tx.status === true || tx.status === '0x1') {
+                swal("Congratulations!", messages.FINALIZED_SUCCESS_MSG, "success").then((result) => {
+                    push(`${commonStore.rootPath}`);
+                });
+            } else {
+                swal("Warning!", messages.FINALIZE_FAILED_TX, "warning").then((result) => {
+                });
+            }
         })
         .on("error", (e) => {
             commonStore.hideLoading();

--- a/src/components/NewBallot.jsx
+++ b/src/components/NewBallot.jsx
@@ -231,7 +231,7 @@ export class NewBallot extends React.Component {
             push(`${commonStore.rootPath}`);
           });
         } else {
-          swal("Warning!", messages.FAILED_TX, "warning").then((result) => {
+          swal("Warning!", messages.BALLOT_CREATE_FAILED_TX, "warning").then((result) => {
           });
         }
       })

--- a/src/messages.js
+++ b/src/messages.js
@@ -30,8 +30,12 @@ messages.SHOULD_BE_MORE_THAN_MIN_DURATION = (minDuration, duration, neededHours,
 messages.SHOULD_BE_LESS_OR_EQUAL_14_DAYS = (duration) => {
 	return `Ballot end time should not be more than 14 days from now in UTC time. Current duration is ${duration} hours.`;
 }
-messages.FAILED_TX = `Your transaction was failed. Please make sure you set correct parameters for ballot creation.
+messages.BALLOT_CREATE_FAILED_TX = `Your transaction was failed. Please make sure you set correct parameters for ballot creation.
 Make sure you don't have Transaction Error. Exception thrown in contract code message in metamask before you sign it.`
+messages.VOTE_FAILED_TX = `Your transaction was failed. Please make sure you haven't already voted for this ballot.
+Make sure you don't have Transaction Error. Exception thrown in contract code message in metamask before you sign it.`
+messages.FINALIZE_FAILED_TX = `Your transaction was failed. Make sure you don't have Transaction Error.
+Exception thrown in contract code message in metamask before you sign it.`
 messages.DESCRIPTION_IS_EMPTY = "Description cannot be empty";
 messages.wrongRepo = (repo) => {
 	return `There is no contracts.json in configured repo ${repo}`;


### PR DESCRIPTION
- (Mandatory) Description
Transaction status is not checked when voting for a ballot or a ballot finalizing. Relates to https://github.com/poanetwork/poa-dapps-voting/issues/123 and https://github.com/poanetwork/poa-dapps-voting/issues/144.

- (Mandatory) What is it: (Fix), (Feature) or (Refactor)
(Fix)