### PR TITLE
(Fix) Checking for zero mining key

### DIFF
--- a/src/components/NewBallot.jsx
+++ b/src/components/NewBallot.jsx
@@ -221,6 +221,15 @@ export class NewBallot extends React.Component {
         let areBallotParamsValid = await contractsStore.votingToChangeKeys.areBallotParamsValid(
           inputToAreBallotParamsValid
         )
+        if (ballotStore.ballotKeys.keysBallotType === ballotStore.KeysBallotType.add) {
+          if (ballotStore.ballotKeys.keyType !== ballotStore.KeyType.mining) {
+            if (!ballotStore.ballotKeys.miningKey.value) {
+              areBallotParamsValid = false
+            } else if (ballotStore.ballotKeys.miningKey.value === '0x0000000000000000000000000000000000000000') {
+              areBallotParamsValid = false
+            }
+          }
+        }
         if (!areBallotParamsValid) {
           commonStore.hideLoading()
           return swal('Warning!', 'The ballot input params are invalid', 'warning')


### PR DESCRIPTION
- (Mandatory) Description
The current `VotingToChangeKey` contract allows creating a ballot for adding voting or payout key with 0x0 mining key (see `VotingToChangeKey.areBallotParamsValid` function: https://github.com/poanetwork/poa-network-consensus-contracts/blob/aa45e19ca50f7cae308c1281d950245b0c65182a/contracts/VotingToChangeKeys.sol#L252). Corresponding issue: https://github.com/poanetwork/poa-dapps-voting/issues/161. This will be fixed in the new contract but for now I propose adding the checking for zero mining key in the code of Voting DApp.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)