### PR TITLE
(Fix) Add some text labels for clear displaying of time

### DIFF
--- a/src/components/BallotCard.jsx
+++ b/src/components/BallotCard.jsx
@@ -757,7 +757,7 @@ export class BallotCard extends React.Component {
           {children}
           <div className="ballots-about-i ballots-about-i_time">
             <div className="ballots-about-td ballots-about-td-title">
-              <p className="ballots-about-i--title">Ballot Time</p>
+              <p className="ballots-about-i--title">Ballot Time (UTC)</p>
             </div>
             <div className="ballots-about-td ballots-about-td-value">
               <p className="ballots-i--created">{this.startTime}</p>

--- a/src/components/BallotEmissionFundsMetadata.jsx
+++ b/src/components/BallotEmissionFundsMetadata.jsx
@@ -29,7 +29,7 @@ export class BallotEmissionFundsMetadata extends React.Component {
   @action('Get beginDateTime and endDateTime')
   getDateTimeLimits = async () => {
     const { votingToManageEmissionFunds } = this.props.contractsStore
-    const dateTimeFormat = 'MM/DD/YYYY HH:mm'
+    const dateTimeFormat = 'MM/DD/YYYY h:mm A'
 
     this.beginDateTime = '...loading date...'
     this.endDateTime = '...loading date...'
@@ -69,7 +69,8 @@ export class BallotEmissionFundsMetadata extends React.Component {
     if (this.noActiveBallotExists === true) {
       note = (
         <p>
-          The ballot can be created starting from <b>{this.beginDateTime}</b> and will end on <b>{this.endDateTime}</b>.
+          The ballot can be created starting from <b>{this.beginDateTime}</b> (local time) and will end on{' '}
+          <b>{this.endDateTime}</b> (local time).
         </p>
       )
     } else if (this.noActiveBallotExists !== true) {


### PR DESCRIPTION
- (Mandatory) Description
A ballot start time is displayed in a ballot card in UTC, so I decided to add the text label `(UTC)` there. Also, begin time and end time are displayed on the `Emission Funds Ballot` tab in a local time zone, so I think we should add `(local time)` labels there.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)