### PR TITLE
(Feature) Auto fetching of EmissionFunds balance every 5 seconds

### DIFF
--- a/src/components/BallotEmissionFundsMetadata.jsx
+++ b/src/components/BallotEmissionFundsMetadata.jsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { observable, action } from 'mobx'
 import { inject, observer } from 'mobx-react'
+import { constants } from '../constants'
 import moment from 'moment'
 
 @inject('ballotStore', 'contractsStore')
 @observer
 export class BallotEmissionFundsMetadata extends React.Component {
-  @observable emissionFundsBalance
+  @observable emissionFundsBalance = 'Loading...'
   @observable noActiveBallotExists
   @observable beginDateTime
   @observable endDateTime
@@ -14,11 +15,8 @@ export class BallotEmissionFundsMetadata extends React.Component {
   @action('Get EmissionFunds balance')
   getEmissionFundsBalance = async () => {
     const { contractsStore } = this.props
-    this.emissionFundsBalance = 'Loading...'
-    this.emissionFundsBalance = contractsStore.web3Instance.fromWei(
-      await contractsStore.emissionFunds.balance(),
-      'ether'
-    )
+    this.emissionFundsBalance =
+      contractsStore.web3Instance.fromWei(await contractsStore.emissionFunds.balance(), 'ether') + ' POA'
   }
 
   @action('Get VotingToManageEmissionFunds.noActiveBallotExists')
@@ -61,6 +59,14 @@ export class BallotEmissionFundsMetadata extends React.Component {
     this.getEmissionFundsBalance()
     this.getNoActiveBallotExists()
     this.getDateTimeLimits()
+  }
+
+  componentDidMount() {
+    this.interval = setInterval(this.getEmissionFundsBalance, constants.getTransactionReceiptInterval)
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.interval)
   }
 
   render() {


### PR DESCRIPTION
- (Mandatory) Description
For now the field `Current amount of funds` on the tab `Emission Funds Ballot` doesn't refresh automatically. I suggest updating its value automatically every 5 seconds.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Feature)