### PR TITLE
(Feature) Add poa-chain-spec branch name and netId for DAI shard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -107,9 +107,11 @@ class App extends Component {
       return this.state.navigationData[0].title
     }
   }
+
   getNetIdClass() {
     const { contractsStore } = this.props
-    return contractsStore.netId === '77' ? 'sokol' : ''
+    const netId = contractsStore.netId
+    return netId === '77' || netId === '79' ? 'sokol' : ''
   }
 
   render() {
@@ -139,7 +141,7 @@ class App extends Component {
         {search}
         <div
           className={`app-container ${this.state.showMobileMenu ? 'app-container-open-mobile-menu' : ''} ${
-            contractsStore.netId === '77' ? 'sokol' : ''
+            contractsStore.netId === '77' || contractsStore.netId === '79' ? 'sokol' : ''
           }`}
         >
           <div className="container">

--- a/src/Loading.js
+++ b/src/Loading.js
@@ -10,8 +10,10 @@ const styles = netId => {
 
   switch (netId) {
     case '77':
+    case '79':
       return sokol
     case '99':
+    case '100':
       return core
     default:
       return {}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -4,7 +4,8 @@ import { Link } from 'react-router-dom'
 import Socials from './Socials.jsx'
 
 export const Footer = ({ netId }) => {
-  const footerClassName = netId === '77' ? 'sokol' : ''
+  const isTestnet = netId === '77' || netId === '79'
+  const footerClassName = isTestnet ? 'sokol' : ''
 
   return (
     <footer className={`footer ${footerClassName}`}>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,10 +9,11 @@ import NavigationLinks from './NavigationLinks.jsx'
 import MobileMenuLinks from './MobileMenuLinks.jsx'
 
 export const Header = ({ netId, baseRootPath, navigationData, showMobileMenu, onMenuToggle }) => {
-  const headerClassName = netId === '77' ? 'sokol' : ''
-  const logoImageName = netId === '77' ? logoSokol : logoBase
-  const menuIcon = netId === '77' ? menuIconSokol : menuIconBase
-  const menuOpenIcon = netId === '77' ? menuOpenIconSokol : menuOpenIconBase
+  const isTestnet = netId === '77' || netId === '79'
+  const headerClassName = isTestnet ? 'sokol' : ''
+  const logoImageName = isTestnet ? logoSokol : logoBase
+  const menuIcon = isTestnet ? menuIconSokol : menuIconBase
+  const menuOpenIcon = isTestnet ? menuOpenIconSokol : menuOpenIconBase
 
   return (
     <header className={`header ${headerClassName}`}>

--- a/src/contracts/addresses.js
+++ b/src/contracts/addresses.js
@@ -10,6 +10,8 @@ import { addressesURL, wrongRepoAlert } from './helpers'
 
 let SOKOL_ADDRESSES = {}
 let CORE_ADDRESSES = {}
+let DAI_TEST_ADDRESSES = {}
+let DAI_ADDRESSES = {}
 
 async function getContractsAddresses(branch) {
   let addr = addressesURL(branch)
@@ -26,8 +28,14 @@ async function getContractsAddresses(branch) {
     case 'core':
       CORE_ADDRESSES = contracts
       break
+    case 'dai':
+      DAI_ADDRESSES = contracts
+      break
     case 'sokol':
       SOKOL_ADDRESSES = contracts
+      break
+    case 'dai-test':
+      DAI_TEST_ADDRESSES = contracts
       break
     default:
       CORE_ADDRESSES = contracts
@@ -39,8 +47,12 @@ function getAddresses(netId) {
   switch (netId) {
     case '77':
       return SOKOL_ADDRESSES
+    case '79':
+      return DAI_TEST_ADDRESSES
     case '99':
       return CORE_ADDRESSES
+    case '100':
+      return DAI_ADDRESSES
     default:
       return CORE_ADDRESSES
   }

--- a/src/contracts/helpers.js
+++ b/src/contracts/helpers.js
@@ -31,8 +31,12 @@ function getBranch(netId) {
   switch (netId) {
     case '77':
       return 'sokol'
+    case '79':
+      return 'dai-test'
     case '99':
       return 'core'
+    case '100':
+      return 'dai'
     default:
       return 'core'
   }

--- a/src/getWeb3.js
+++ b/src/getWeb3.js
@@ -16,9 +16,17 @@ let getWeb3 = () => {
           let netIdName
           console.log('netId', netId)
           switch (netId) {
+            case '100':
+              netIdName = 'Dai'
+              console.log('This is Dai', netId)
+              break
             case '99':
               netIdName = 'Core'
               console.log('This is Core', netId)
+              break
+            case '79':
+              netIdName = 'Dai-Test'
+              console.log('This is Dai-Test', netId)
               break
             case '77':
               netIdName = 'Sokol'


### PR DESCRIPTION
- (Mandatory) Description
These changes add `netId` and poa-chain-spec branch name for new DAI network (shard).
For `dai-test` netId = `79` and for `dai` netId = `100`. The code defining `netId` for different networks is refactored in the next PR: https://github.com/poanetwork/poa-dapps-voting/pull/177. So, this PR should be merged before https://github.com/poanetwork/poa-dapps-voting/pull/177 is merged.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Feature)