### PR TITLE
(Fix, Refactor) Add support of a new version of MetaMask

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import { Route } from 'react-router-dom'
 import { inject, observer } from 'mobx-react'
 import swal from 'sweetalert2'
 import { messages } from './messages'
-import { isTestnet } from './helpers'
+import { constants } from './constants'
 
 @inject('commonStore', 'contractsStore')
 @observer
@@ -124,8 +124,8 @@ class App extends Component {
   }
 
   getNetIdClass() {
-    const { contractsStore } = this.props
-    return isTestnet(contractsStore.netId) ? 'sokol' : ''
+    const { netId } = this.props.contractsStore
+    return netId in constants.NETWORKS && constants.NETWORKS[netId].TESTNET ? 'sokol' : ''
   }
 
   render() {
@@ -142,6 +142,8 @@ class App extends Component {
       ''
     )
 
+    const isTestnet = contractsStore.netId in constants.NETWORKS && constants.NETWORKS[contractsStore.netId].TESTNET
+
     return (
       <section className={`content ${this.state.showMobileMenu ? 'content-menu-open' : ''}`}>
         {loading}
@@ -155,7 +157,7 @@ class App extends Component {
         {search}
         <div
           className={`app-container ${this.state.showMobileMenu ? 'app-container-open-mobile-menu' : ''} ${
-            isTestnet(contractsStore.netId) ? 'sokol' : ''
+            isTestnet ? 'sokol' : ''
           }`}
         >
           <div className="container">

--- a/src/Loading.js
+++ b/src/Loading.js
@@ -9,16 +9,11 @@ const styles = netId => {
     backgroundColor: 'rgba(47, 109, 99, 0.8)'
   }
 
-  switch (netId) {
-    case constants.NETID_SOKOL:
-    case constants.NETID_DAI_TEST:
-      return sokol
-    case constants.NETID_CORE:
-    case constants.NETID_DAI:
-      return core
-    default:
-      return {}
+  if (netId in constants.NETWORKS) {
+    return constants.NETWORKS[netId].TESTNET ? sokol : core
   }
+
+  return core
 }
 const Loading = ({ netId }) => (
   <div className="loading-container" style={styles(netId)}>

--- a/src/components/BallotEmissionFundsCard.jsx
+++ b/src/components/BallotEmissionFundsCard.jsx
@@ -7,7 +7,7 @@ import { BallotCard } from './BallotCard.jsx'
 export class BallotEmissionFundsCard extends React.Component {
   render() {
     const { id, votingState, pos, contractsStore } = this.props
-    const amount = contractsStore.web3Instance.fromWei(votingState.amount, 'ether')
+    const amount = contractsStore.web3Instance.utils.fromWei(votingState.amount, 'ether')
     return (
       <BallotCard votingType="votingToManageEmissionFunds" votingState={votingState} id={id} pos={pos}>
         <div className="ballots-about-i ballots-about-i_proposed_receiver">

--- a/src/components/BallotEmissionFundsMetadata.jsx
+++ b/src/components/BallotEmissionFundsMetadata.jsx
@@ -82,7 +82,7 @@ export class BallotEmissionFundsMetadata extends React.Component {
     } else if (this.noActiveBallotExists !== true) {
       note = <p>To be able to create a new ballot, the previous ballot of this type must be finalized.</p>
     }
-    if (contractsStore.netId === constants.NETID_SOKOL) {
+    if (constants.NETWORKS[contractsStore.netId].NAME.toLowerCase() === 'sokol') {
       explorerLink = `https://sokol.poaexplorer.com/address/search/${contractsStore.emissionFunds.address}`
     } else {
       explorerLink = `https://poaexplorer.com/address/${contractsStore.emissionFunds.address}`

--- a/src/components/BallotEmissionFundsMetadata.jsx
+++ b/src/components/BallotEmissionFundsMetadata.jsx
@@ -16,7 +16,7 @@ export class BallotEmissionFundsMetadata extends React.Component {
   getEmissionFundsBalance = async () => {
     const { contractsStore } = this.props
     this.emissionFundsBalance =
-      contractsStore.web3Instance.fromWei(await contractsStore.emissionFunds.balance(), 'ether') + ' POA'
+      contractsStore.web3Instance.utils.fromWei(await contractsStore.emissionFunds.balance(), 'ether') + ' POA'
   }
 
   @action('Get VotingToManageEmissionFunds.noActiveBallotExists')

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,10 +2,10 @@ import React from 'react'
 import moment from 'moment'
 import { Link } from 'react-router-dom'
 import Socials from './Socials.jsx'
-import { isTestnet } from '../helpers'
+import { constants } from '../constants'
 
 export const Footer = ({ netId }) => {
-  const footerClassName = isTestnet(netId) ? 'sokol' : ''
+  const footerClassName = netId in constants.NETWORKS && constants.NETWORKS[netId].TESTNET ? 'sokol' : ''
 
   return (
     <footer className={`footer ${footerClassName}`}>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -7,10 +7,10 @@ import menuOpenIconBase from '../assets/images/icons/icon-close.svg'
 import menuOpenIconSokol from '../assets/images/icons/icon-close-sokol.svg'
 import NavigationLinks from './NavigationLinks.jsx'
 import MobileMenuLinks from './MobileMenuLinks.jsx'
-import { isTestnet } from '../helpers'
+import { constants } from '../constants'
 
 export const Header = ({ netId, baseRootPath, navigationData, showMobileMenu, onMenuToggle }) => {
-  const thisIsTestnet = isTestnet(netId)
+  const thisIsTestnet = netId in constants.NETWORKS && constants.NETWORKS[netId].TESTNET
   const headerClassName = thisIsTestnet ? 'sokol' : ''
   const logoImageName = thisIsTestnet ? logoSokol : logoBase
   const menuIcon = thisIsTestnet ? menuIconSokol : menuIconBase

--- a/src/components/NewBallot.jsx
+++ b/src/components/NewBallot.jsx
@@ -100,7 +100,7 @@ export class NewBallot extends React.Component {
         }
       }
 
-      let isAffectedKeyAddress = contractsStore.web3Instance.isAddress(ballotStore.ballotKeys.affectedKey)
+      let isAffectedKeyAddress = contractsStore.web3Instance.utils.isAddress(ballotStore.ballotKeys.affectedKey)
 
       if (!isAffectedKeyAddress) {
         swal('Warning!', messages.AFFECTED_KEY_IS_NOT_ADDRESS_MSG, 'warning')
@@ -108,7 +108,7 @@ export class NewBallot extends React.Component {
         return false
       }
 
-      let isMiningKeyAddress = contractsStore.web3Instance.isAddress(ballotStore.ballotKeys.miningKey.value)
+      let isMiningKeyAddress = contractsStore.web3Instance.utils.isAddress(ballotStore.ballotKeys.miningKey.value)
       if (!isMiningKeyAddress) {
         swal('Warning!', messages.MINING_KEY_IS_NOT_ADDRESS_MSG, 'warning')
         commonStore.hideLoading()
@@ -135,7 +135,7 @@ export class NewBallot extends React.Component {
         }
       }
 
-      const isAddress = contractsStore.web3Instance.isAddress(ballotStore.ballotProxy.proposedAddress)
+      const isAddress = contractsStore.web3Instance.utils.isAddress(ballotStore.ballotProxy.proposedAddress)
 
       if (!isAddress) {
         swal('Warning!', messages.PROPOSED_ADDRESS_IS_NOT_ADDRESS_MSG, 'warning')
@@ -151,7 +151,7 @@ export class NewBallot extends React.Component {
         return false
       }
 
-      const isAddress = contractsStore.web3Instance.isAddress(ballotStore.ballotEmissionFunds.receiver)
+      const isAddress = contractsStore.web3Instance.utils.isAddress(ballotStore.ballotEmissionFunds.receiver)
 
       if (!isAddress) {
         swal('Warning!', messages.PROPOSED_ADDRESS_IS_NOT_ADDRESS_MSG, 'warning')
@@ -320,17 +320,17 @@ export class NewBallot extends React.Component {
         case ballotStore.BallotType.keys:
           methodToCreateBallot = this.createBallotForKeys
           contractType = 'votingToChangeKeys'
-          contractInstance = contractsStore.votingToChangeKeys.votingToChangeKeysInstance
+          contractInstance = contractsStore.votingToChangeKeys.instance
           break
         case ballotStore.BallotType.minThreshold:
           methodToCreateBallot = this.createBallotForMinThreshold
           contractType = 'votingToChangeMinThreshold'
-          contractInstance = contractsStore.votingToChangeMinThreshold.votingToChangeMinThresholdInstance
+          contractInstance = contractsStore.votingToChangeMinThreshold.instance
           break
         case ballotStore.BallotType.proxy:
           methodToCreateBallot = this.createBallotForProxy
           contractType = 'votingToChangeProxy'
-          contractInstance = contractsStore.votingToChangeProxy.votingToChangeProxyInstance
+          contractInstance = contractsStore.votingToChangeProxy.instance
           break
         case ballotStore.BallotType.emissionFunds:
           methodToCreateBallot = this.createBallotForEmissionFunds

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,25 +28,21 @@ constants.getTransactionReceiptInterval = 5000
 constants.NETWORKS = {
   '77': {
     NAME: 'Sokol',
-    RPC: 'https://sokol.poa.network',
     BRANCH: 'sokol',
     TESTNET: true
   },
   '99': {
     NAME: 'Core',
-    RPC: 'https://core.poa.network',
     BRANCH: 'core',
     TESTNET: false
   },
   '79': {
     NAME: 'Dai-Test',
-    RPC: 'http://40.112.48.125',
     BRANCH: 'dai-test',
     TESTNET: true
   },
   '100': {
     NAME: 'Dai',
-    RPC: 'https://dai.poa.network',
     BRANCH: 'dai',
     TESTNET: false
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -24,10 +24,34 @@ constants.minBallotDurationInDays = 2
 constants.startTimeOffsetInMinutes = 5
 constants.endTimeDefaultInMinutes = 2890
 constants.getTransactionReceiptInterval = 5000
-constants.NETID_SOKOL = '77'
-constants.NETID_CORE = '99'
-constants.NETID_DAI_TEST = '79'
-constants.NETID_DAI = '100'
+
+constants.NETWORKS = {
+  '77': {
+    NAME: 'Sokol',
+    RPC: 'https://sokol.poa.network',
+    BRANCH: 'sokol',
+    TESTNET: true
+  },
+  '99': {
+    NAME: 'Core',
+    RPC: 'https://core.poa.network',
+    BRANCH: 'core',
+    TESTNET: false
+  },
+  '79': {
+    NAME: 'Dai-Test',
+    RPC: 'http://40.112.48.125',
+    BRANCH: 'dai-test',
+    TESTNET: true
+  },
+  '100': {
+    NAME: 'Dai',
+    RPC: 'https://dai.poa.network',
+    BRANCH: 'dai',
+    TESTNET: false
+  }
+}
+
 module.exports = {
   constants
 }

--- a/src/contracts/BallotsStorage.contract.js
+++ b/src/contracts/BallotsStorage.contract.js
@@ -1,15 +1,15 @@
 import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
+import { constants } from '../constants'
 
 export default class BallotsStorage {
   async init({ web3, netId }) {
-    const { BALLOTS_STORAGE_ADDRESS } = networkAddresses(netId)
+    const { BALLOTS_STORAGE_ADDRESS } = networkAddresses()
     console.log('Ballots Storage address', BALLOTS_STORAGE_ADDRESS)
     const web3_10 = new Web3(web3.currentProvider)
-    const branch = helpers.getBranch(netId)
 
-    const ballotsStorageAbi = await helpers.getABI(branch, 'BallotStorage')
+    const ballotsStorageAbi = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'BallotStorage')
 
     this.ballotsStorageInstance = new web3_10.eth.Contract(ballotsStorageAbi, BALLOTS_STORAGE_ADDRESS)
   }

--- a/src/contracts/BallotsStorage.contract.js
+++ b/src/contracts/BallotsStorage.contract.js
@@ -1,4 +1,3 @@
-import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
 import { constants } from '../constants'
@@ -7,19 +6,16 @@ export default class BallotsStorage {
   async init({ web3, netId }) {
     const { BALLOTS_STORAGE_ADDRESS } = networkAddresses()
     console.log('Ballots Storage address', BALLOTS_STORAGE_ADDRESS)
-    const web3_10 = new Web3(web3.currentProvider)
 
     const ballotsStorageAbi = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'BallotStorage')
 
-    this.ballotsStorageInstance = new web3_10.eth.Contract(ballotsStorageAbi, BALLOTS_STORAGE_ADDRESS)
+    this.instance = new web3.eth.Contract(ballotsStorageAbi, BALLOTS_STORAGE_ADDRESS)
   }
 
   areKeysBallotParamsValid({ ballotType, affectedKeyType, affectedKey, miningKey }) {
-    if (!this.ballotsStorageInstance.methods.areKeysBallotParamsValid) {
+    if (!this.instance.methods.areKeysBallotParamsValid) {
       return null
     }
-    return this.ballotsStorageInstance.methods
-      .areKeysBallotParamsValid(ballotType, affectedKeyType, affectedKey, miningKey)
-      .call()
+    return this.instance.methods.areKeysBallotParamsValid(ballotType, affectedKeyType, affectedKey, miningKey).call()
   }
 }

--- a/src/contracts/EmissionFunds.contract.js
+++ b/src/contracts/EmissionFunds.contract.js
@@ -3,7 +3,7 @@ import { networkAddresses } from './addresses'
 
 export default class EmissionFunds {
   async init({ web3, netId }) {
-    const { EMISSION_FUNDS_ADDRESS } = networkAddresses(netId)
+    const { EMISSION_FUNDS_ADDRESS } = networkAddresses()
     console.log('EmissionFunds address', EMISSION_FUNDS_ADDRESS)
     this.web3_10 = new Web3(web3.currentProvider)
     this.address = EMISSION_FUNDS_ADDRESS

--- a/src/contracts/EmissionFunds.contract.js
+++ b/src/contracts/EmissionFunds.contract.js
@@ -1,15 +1,14 @@
-import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 
 export default class EmissionFunds {
   async init({ web3, netId }) {
     const { EMISSION_FUNDS_ADDRESS } = networkAddresses()
     console.log('EmissionFunds address', EMISSION_FUNDS_ADDRESS)
-    this.web3_10 = new Web3(web3.currentProvider)
+    this.web3 = web3
     this.address = EMISSION_FUNDS_ADDRESS
   }
 
   balance() {
-    return this.web3_10.eth.getBalance(this.address)
+    return this.web3.eth.getBalance(this.address)
   }
 }

--- a/src/contracts/KeysManager.contract.js
+++ b/src/contracts/KeysManager.contract.js
@@ -1,16 +1,15 @@
 import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
+import { constants } from '../constants'
 
 export default class KeysManager {
   async init({ web3, netId }) {
-    const { KEYS_MANAGER_ADDRESS } = networkAddresses(netId)
+    const { KEYS_MANAGER_ADDRESS } = networkAddresses()
     console.log('KeysManager address', KEYS_MANAGER_ADDRESS)
     const web3_10 = new Web3(web3.currentProvider)
 
-    const branch = helpers.getBranch(netId)
-
-    const keysManagerABI = await helpers.getABI(branch, 'KeysManager')
+    const keysManagerABI = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'KeysManager')
 
     this.instance = new web3_10.eth.Contract(keysManagerABI, KEYS_MANAGER_ADDRESS)
     this.address = KEYS_MANAGER_ADDRESS

--- a/src/contracts/KeysManager.contract.js
+++ b/src/contracts/KeysManager.contract.js
@@ -1,4 +1,3 @@
-import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
 import { constants } from '../constants'
@@ -7,11 +6,10 @@ export default class KeysManager {
   async init({ web3, netId }) {
     const { KEYS_MANAGER_ADDRESS } = networkAddresses()
     console.log('KeysManager address', KEYS_MANAGER_ADDRESS)
-    const web3_10 = new Web3(web3.currentProvider)
 
     const keysManagerABI = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'KeysManager')
 
-    this.instance = new web3_10.eth.Contract(keysManagerABI, KEYS_MANAGER_ADDRESS)
+    this.instance = new web3.eth.Contract(keysManagerABI, KEYS_MANAGER_ADDRESS)
     this.address = KEYS_MANAGER_ADDRESS
   }
 }

--- a/src/contracts/PoaConsensus.contract.js
+++ b/src/contracts/PoaConsensus.contract.js
@@ -1,4 +1,3 @@
-import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
 import { constants } from '../constants'
@@ -7,14 +6,13 @@ export default class PoaConsensus {
   async init({ web3, netId }) {
     const { POA_ADDRESS } = networkAddresses()
     console.log('POA address', POA_ADDRESS)
-    const web3_10 = new Web3(web3.currentProvider)
 
     const poaConsensusAbi = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'PoaNetworkConsensus')
 
-    this.poaInstance = new web3_10.eth.Contract(poaConsensusAbi, POA_ADDRESS)
+    this.instance = new web3.eth.Contract(poaConsensusAbi, POA_ADDRESS)
   }
 
   async getValidators() {
-    return await this.poaInstance.methods.getValidators().call()
+    return await this.instance.methods.getValidators().call()
   }
 }

--- a/src/contracts/PoaConsensus.contract.js
+++ b/src/contracts/PoaConsensus.contract.js
@@ -1,16 +1,15 @@
 import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
+import { constants } from '../constants'
 
-export default class POAConsensus {
+export default class PoaConsensus {
   async init({ web3, netId }) {
-    const { POA_ADDRESS } = networkAddresses(netId)
+    const { POA_ADDRESS } = networkAddresses()
     console.log('POA address', POA_ADDRESS)
     const web3_10 = new Web3(web3.currentProvider)
 
-    const branch = helpers.getBranch(netId)
-
-    const poaConsensusAbi = await helpers.getABI(branch, 'PoaNetworkConsensus')
+    const poaConsensusAbi = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'PoaNetworkConsensus')
 
     this.poaInstance = new web3_10.eth.Contract(poaConsensusAbi, POA_ADDRESS)
   }

--- a/src/contracts/ProxyStorage.contract.js
+++ b/src/contracts/ProxyStorage.contract.js
@@ -1,15 +1,15 @@
 import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
+import { constants } from '../constants'
 
 export default class ProxyStorage {
   async init({ web3, netId }) {
-    const { PROXY_ADDRESS } = networkAddresses(netId)
+    const { PROXY_ADDRESS } = networkAddresses()
     console.log('Proxy Storage address', PROXY_ADDRESS)
     const web3_10 = new Web3(web3.currentProvider)
-    const branch = helpers.getBranch(netId)
 
-    const proxyStorageAbi = await helpers.getABI(branch, 'ProxyStorage')
+    const proxyStorageAbi = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'ProxyStorage')
 
     this.proxyStorageInstance = new web3_10.eth.Contract(proxyStorageAbi, PROXY_ADDRESS)
   }

--- a/src/contracts/ProxyStorage.contract.js
+++ b/src/contracts/ProxyStorage.contract.js
@@ -1,4 +1,3 @@
-import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
 import { constants } from '../constants'
@@ -7,14 +6,13 @@ export default class ProxyStorage {
   async init({ web3, netId }) {
     const { PROXY_ADDRESS } = networkAddresses()
     console.log('Proxy Storage address', PROXY_ADDRESS)
-    const web3_10 = new Web3(web3.currentProvider)
 
     const proxyStorageAbi = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'ProxyStorage')
 
-    this.proxyStorageInstance = new web3_10.eth.Contract(proxyStorageAbi, PROXY_ADDRESS)
+    this.instance = new web3.eth.Contract(proxyStorageAbi, PROXY_ADDRESS)
   }
 
   doesMethodExist(methodName) {
-    return this.proxyStorageInstance && this.proxyStorageInstance.methods[methodName]
+    return this.instance && this.instance.methods[methodName]
   }
 }

--- a/src/contracts/ValidatorMetadata.contract.js
+++ b/src/contracts/ValidatorMetadata.contract.js
@@ -2,16 +2,15 @@ import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
 import { toAscii } from '../helpers'
+import { constants } from '../constants'
 
 export default class ValidatorMetadata {
   async init({ web3, netId }) {
-    const { METADATA_ADDRESS } = networkAddresses(netId)
+    const { METADATA_ADDRESS } = networkAddresses()
     console.log('Metadata address', METADATA_ADDRESS)
     const web3_10 = new Web3(web3.currentProvider)
 
-    const branch = helpers.getBranch(netId)
-
-    const MetadataAbi = await helpers.getABI(branch, 'ValidatorMetadata')
+    const MetadataAbi = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'ValidatorMetadata')
 
     this.metadataInstance = new web3_10.eth.Contract(MetadataAbi, METADATA_ADDRESS)
   }

--- a/src/contracts/ValidatorMetadata.contract.js
+++ b/src/contracts/ValidatorMetadata.contract.js
@@ -1,4 +1,3 @@
-import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
 import { toAscii } from '../helpers'
@@ -8,19 +7,18 @@ export default class ValidatorMetadata {
   async init({ web3, netId }) {
     const { METADATA_ADDRESS } = networkAddresses()
     console.log('Metadata address', METADATA_ADDRESS)
-    const web3_10 = new Web3(web3.currentProvider)
 
     const MetadataAbi = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'ValidatorMetadata')
 
-    this.metadataInstance = new web3_10.eth.Contract(MetadataAbi, METADATA_ADDRESS)
+    this.instance = new web3.eth.Contract(MetadataAbi, METADATA_ADDRESS)
   }
 
   async getValidatorFullName(miningKey) {
     let validator
-    if (this.metadataInstance.methods.getValidatorName) {
-      validator = await this.metadataInstance.methods.getValidatorName(miningKey).call()
+    if (this.instance.methods.getValidatorName) {
+      validator = await this.instance.methods.getValidatorName(miningKey).call()
     } else {
-      validator = await this.metadataInstance.methods.validators(miningKey).call()
+      validator = await this.instance.methods.validators(miningKey).call()
     }
     return {
       firstName: toAscii(validator.firstName),

--- a/src/contracts/VotingToChangeKeys.contract.js
+++ b/src/contracts/VotingToChangeKeys.contract.js
@@ -1,4 +1,3 @@
-import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
 import { constants } from '../constants'
@@ -7,40 +6,37 @@ export default class VotingToChangeKeys {
   async init({ web3, netId }) {
     const { VOTING_TO_CHANGE_KEYS_ADDRESS } = networkAddresses()
     console.log('VotingToChangeKeys address', VOTING_TO_CHANGE_KEYS_ADDRESS)
-    const web3_10 = new Web3(web3.currentProvider)
 
     const votingToChangeKeysABI = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'VotingToChangeKeys')
 
-    this.votingToChangeKeysInstance = new web3_10.eth.Contract(votingToChangeKeysABI, VOTING_TO_CHANGE_KEYS_ADDRESS)
-    this.gasPrice = web3_10.utils.toWei('1', 'gwei')
+    this.instance = new web3.eth.Contract(votingToChangeKeysABI, VOTING_TO_CHANGE_KEYS_ADDRESS)
     this.address = VOTING_TO_CHANGE_KEYS_ADDRESS
-    this.instance = this.votingToChangeKeysInstance
   }
 
   //setters
   createBallot({ startTime, endTime, affectedKey, affectedKeyType, miningKey, ballotType, memo }) {
-    if (this.votingToChangeKeysInstance.methods.createBallot) {
-      return this.votingToChangeKeysInstance.methods
+    if (this.instance.methods.createBallot) {
+      return this.instance.methods
         .createBallot(startTime, endTime, ballotType, affectedKeyType, memo, affectedKey, miningKey)
         .encodeABI()
     }
-    return this.votingToChangeKeysInstance.methods
+    return this.instance.methods
       .createVotingForKeys(startTime, endTime, affectedKey, affectedKeyType, miningKey, ballotType, memo)
       .encodeABI()
   }
 
   createBallotToAddNewValidator({ startTime, endTime, memo, affectedKey, newVotingKey, newPayoutKey }) {
-    return this.votingToChangeKeysInstance.methods
+    return this.instance.methods
       .createBallotToAddNewValidator(startTime, endTime, memo, affectedKey, newVotingKey, newPayoutKey)
       .encodeABI()
   }
 
   vote(_id, choice) {
-    return this.votingToChangeKeysInstance.methods.vote(_id, choice).encodeABI()
+    return this.instance.methods.vote(_id, choice).encodeABI()
   }
 
   finalize(_id) {
-    return this.votingToChangeKeysInstance.methods.finalize(_id).encodeABI()
+    return this.instance.methods.finalize(_id).encodeABI()
   }
 
   //getters
@@ -48,47 +44,45 @@ export default class VotingToChangeKeys {
     if (!this.doesMethodExist('areBallotParamsValid')) {
       return null
     }
-    return this.votingToChangeKeysInstance.methods
-      .areBallotParamsValid(ballotType, affectedKey, affectedKeyType, miningKey)
-      .call()
+    return this.instance.methods.areBallotParamsValid(ballotType, affectedKey, affectedKeyType, miningKey).call()
   }
 
   doesMethodExist(methodName) {
-    return this.votingToChangeKeysInstance && this.votingToChangeKeysInstance.methods[methodName]
+    return this.instance && this.instance.methods[methodName]
   }
 
   nextBallotId() {
-    return this.votingToChangeKeysInstance.methods.nextBallotId().call()
+    return this.instance.methods.nextBallotId().call()
   }
 
   getBallotInfo(_id, _votingKey) {
     if (this.doesMethodExist('getBallotInfo')) {
-      return this.votingToChangeKeysInstance.methods.getBallotInfo(_id).call()
+      return this.instance.methods.getBallotInfo(_id).call()
     }
-    return this.votingToChangeKeysInstance.methods.votingState(_id).call()
+    return this.instance.methods.votingState(_id).call()
   }
 
   hasAlreadyVoted(_id, votingKey) {
-    return this.votingToChangeKeysInstance.methods.hasAlreadyVoted(_id, votingKey).call()
+    return this.instance.methods.hasAlreadyVoted(_id, votingKey).call()
   }
 
   isValidVote(_id, votingKey) {
-    return this.votingToChangeKeysInstance.methods.isValidVote(_id, votingKey).call()
+    return this.instance.methods.isValidVote(_id, votingKey).call()
   }
 
   isActive(_id) {
-    return this.votingToChangeKeysInstance.methods.isActive(_id).call()
+    return this.instance.methods.isActive(_id).call()
   }
 
   canBeFinalizedNow(_id) {
     if (this.doesMethodExist('canBeFinalizedNow')) {
-      return this.votingToChangeKeysInstance.methods.canBeFinalizedNow(_id).call()
+      return this.instance.methods.canBeFinalizedNow(_id).call()
     }
     return null
   }
 
   async getBallotLimit(_miningKey, _limitPerValidator) {
-    const _activeBallots = await this.votingToChangeKeysInstance.methods.validatorActiveBallots(_miningKey).call()
+    const _activeBallots = await this.instance.methods.validatorActiveBallots(_miningKey).call()
     return _limitPerValidator - _activeBallots
   }
 }

--- a/src/contracts/VotingToChangeKeys.contract.js
+++ b/src/contracts/VotingToChangeKeys.contract.js
@@ -1,16 +1,15 @@
 import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
+import { constants } from '../constants'
 
 export default class VotingToChangeKeys {
   async init({ web3, netId }) {
-    const { VOTING_TO_CHANGE_KEYS_ADDRESS } = networkAddresses(netId)
+    const { VOTING_TO_CHANGE_KEYS_ADDRESS } = networkAddresses()
     console.log('VotingToChangeKeys address', VOTING_TO_CHANGE_KEYS_ADDRESS)
     const web3_10 = new Web3(web3.currentProvider)
 
-    const branch = helpers.getBranch(netId)
-
-    const votingToChangeKeysABI = await helpers.getABI(branch, 'VotingToChangeKeys')
+    const votingToChangeKeysABI = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'VotingToChangeKeys')
 
     this.votingToChangeKeysInstance = new web3_10.eth.Contract(votingToChangeKeysABI, VOTING_TO_CHANGE_KEYS_ADDRESS)
     this.gasPrice = web3_10.utils.toWei('1', 'gwei')

--- a/src/contracts/VotingToChangeMinThreshold.contract.js
+++ b/src/contracts/VotingToChangeMinThreshold.contract.js
@@ -1,4 +1,3 @@
-import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
 import { constants } from '../constants'
@@ -7,83 +6,75 @@ export default class VotingToChangeMinThreshold {
   async init({ web3, netId }) {
     const { VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS } = networkAddresses()
     console.log('VotingToChangeMinThreshold address', VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS)
-    const web3_10 = new Web3(web3.currentProvider)
 
     const votingToChangeMinThresholdABI = await helpers.getABI(
       constants.NETWORKS[netId].BRANCH,
       'VotingToChangeMinThreshold'
     )
 
-    this.votingToChangeMinThresholdInstance = new web3_10.eth.Contract(
-      votingToChangeMinThresholdABI,
-      VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS
-    )
-    this.gasPrice = web3_10.utils.toWei('1', 'gwei')
+    this.instance = new web3.eth.Contract(votingToChangeMinThresholdABI, VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS)
     this.address = VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS
-    this.instance = this.votingToChangeMinThresholdInstance
   }
 
   //setters
   createBallot({ startTime, endTime, proposedValue, memo }) {
     let method
-    if (this.votingToChangeMinThresholdInstance.methods.createBallot) {
-      method = this.votingToChangeMinThresholdInstance.methods.createBallot
+    if (this.instance.methods.createBallot) {
+      method = this.instance.methods.createBallot
     } else {
-      method = this.votingToChangeMinThresholdInstance.methods.createBallotToChangeThreshold
+      method = this.instance.methods.createBallotToChangeThreshold
     }
     return method(startTime, endTime, proposedValue, memo).encodeABI()
   }
 
   vote(_id, choice) {
-    return this.votingToChangeMinThresholdInstance.methods.vote(_id, choice).encodeABI()
+    return this.instance.methods.vote(_id, choice).encodeABI()
   }
 
   finalize(_id) {
-    return this.votingToChangeMinThresholdInstance.methods.finalize(_id).encodeABI()
+    return this.instance.methods.finalize(_id).encodeABI()
   }
 
   //getters
   doesMethodExist(methodName) {
-    if (this.votingToChangeMinThresholdInstance.methods[methodName]) {
+    if (this.instance.methods[methodName]) {
       return true
     }
     return false
   }
 
   nextBallotId() {
-    return this.votingToChangeMinThresholdInstance.methods.nextBallotId().call()
+    return this.instance.methods.nextBallotId().call()
   }
 
   getBallotInfo(_id, _votingKey) {
     if (this.doesMethodExist('getBallotInfo')) {
-      return this.votingToChangeMinThresholdInstance.methods.getBallotInfo(_id, _votingKey).call()
+      return this.instance.methods.getBallotInfo(_id, _votingKey).call()
     }
-    return this.votingToChangeMinThresholdInstance.methods.votingState(_id).call()
+    return this.instance.methods.votingState(_id).call()
   }
 
   hasAlreadyVoted(_id, votingKey) {
-    return this.votingToChangeMinThresholdInstance.methods.hasAlreadyVoted(_id, votingKey).call()
+    return this.instance.methods.hasAlreadyVoted(_id, votingKey).call()
   }
 
   isValidVote(_id, votingKey) {
-    return this.votingToChangeMinThresholdInstance.methods.isValidVote(_id, votingKey).call()
+    return this.instance.methods.isValidVote(_id, votingKey).call()
   }
 
   isActive(_id) {
-    return this.votingToChangeMinThresholdInstance.methods.isActive(_id).call()
+    return this.instance.methods.isActive(_id).call()
   }
 
   canBeFinalizedNow(_id) {
     if (this.doesMethodExist('canBeFinalizedNow')) {
-      return this.votingToChangeMinThresholdInstance.methods.canBeFinalizedNow(_id).call()
+      return this.instance.methods.canBeFinalizedNow(_id).call()
     }
     return null
   }
 
   async getBallotLimit(_miningKey, _limitPerValidator) {
-    const _activeBallots = await this.votingToChangeMinThresholdInstance.methods
-      .validatorActiveBallots(_miningKey)
-      .call()
+    const _activeBallots = await this.instance.methods.validatorActiveBallots(_miningKey).call()
     return _limitPerValidator - _activeBallots
   }
 }

--- a/src/contracts/VotingToChangeMinThreshold.contract.js
+++ b/src/contracts/VotingToChangeMinThreshold.contract.js
@@ -1,16 +1,18 @@
 import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
+import { constants } from '../constants'
 
 export default class VotingToChangeMinThreshold {
   async init({ web3, netId }) {
-    const { VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS } = networkAddresses(netId)
+    const { VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS } = networkAddresses()
     console.log('VotingToChangeMinThreshold address', VOTING_TO_CHANGE_MIN_THRESHOLD_ADDRESS)
     const web3_10 = new Web3(web3.currentProvider)
 
-    const branch = helpers.getBranch(netId)
-
-    const votingToChangeMinThresholdABI = await helpers.getABI(branch, 'VotingToChangeMinThreshold')
+    const votingToChangeMinThresholdABI = await helpers.getABI(
+      constants.NETWORKS[netId].BRANCH,
+      'VotingToChangeMinThreshold'
+    )
 
     this.votingToChangeMinThresholdInstance = new web3_10.eth.Contract(
       votingToChangeMinThresholdABI,

--- a/src/contracts/VotingToChangeProxy.contract.js
+++ b/src/contracts/VotingToChangeProxy.contract.js
@@ -1,16 +1,15 @@
 import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
+import { constants } from '../constants'
 
 export default class VotingToChangeProxy {
   async init({ web3, netId }) {
-    const { VOTING_TO_CHANGE_PROXY_ADDRESS } = networkAddresses(netId)
+    const { VOTING_TO_CHANGE_PROXY_ADDRESS } = networkAddresses()
     console.log('VotingToChangeProxy address', VOTING_TO_CHANGE_PROXY_ADDRESS)
     const web3_10 = new Web3(web3.currentProvider)
 
-    const branch = helpers.getBranch(netId)
-
-    const votingToChangeProxyABI = await helpers.getABI(branch, 'VotingToChangeProxyAddress')
+    const votingToChangeProxyABI = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'VotingToChangeProxyAddress')
 
     this.votingToChangeProxyInstance = new web3_10.eth.Contract(votingToChangeProxyABI, VOTING_TO_CHANGE_PROXY_ADDRESS)
     this.gasPrice = web3_10.utils.toWei('1', 'gwei')

--- a/src/contracts/VotingToChangeProxy.contract.js
+++ b/src/contracts/VotingToChangeProxy.contract.js
@@ -1,4 +1,3 @@
-import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
 import { constants } from '../constants'
@@ -7,76 +6,71 @@ export default class VotingToChangeProxy {
   async init({ web3, netId }) {
     const { VOTING_TO_CHANGE_PROXY_ADDRESS } = networkAddresses()
     console.log('VotingToChangeProxy address', VOTING_TO_CHANGE_PROXY_ADDRESS)
-    const web3_10 = new Web3(web3.currentProvider)
 
     const votingToChangeProxyABI = await helpers.getABI(constants.NETWORKS[netId].BRANCH, 'VotingToChangeProxyAddress')
 
-    this.votingToChangeProxyInstance = new web3_10.eth.Contract(votingToChangeProxyABI, VOTING_TO_CHANGE_PROXY_ADDRESS)
-    this.gasPrice = web3_10.utils.toWei('1', 'gwei')
+    this.instance = new web3.eth.Contract(votingToChangeProxyABI, VOTING_TO_CHANGE_PROXY_ADDRESS)
     this.address = VOTING_TO_CHANGE_PROXY_ADDRESS
-    this.instance = this.votingToChangeProxyInstance
   }
 
   //setters
   createBallot({ startTime, endTime, proposedValue, contractType, memo }) {
-    if (!this.votingToChangeProxyInstance.methods.createBallot) {
-      return this.votingToChangeProxyInstance.methods
+    if (!this.instance.methods.createBallot) {
+      return this.instance.methods
         .createBallotToChangeProxyAddress(startTime, endTime, proposedValue, contractType, memo)
         .encodeABI()
     }
-    return this.votingToChangeProxyInstance.methods
-      .createBallot(startTime, endTime, contractType, memo, proposedValue)
-      .encodeABI()
+    return this.instance.methods.createBallot(startTime, endTime, contractType, memo, proposedValue).encodeABI()
   }
 
   vote(_id, choice) {
-    return this.votingToChangeProxyInstance.methods.vote(_id, choice).encodeABI()
+    return this.instance.methods.vote(_id, choice).encodeABI()
   }
 
   finalize(_id) {
-    return this.votingToChangeProxyInstance.methods.finalize(_id).encodeABI()
+    return this.instance.methods.finalize(_id).encodeABI()
   }
 
   //getters
   doesMethodExist(methodName) {
-    if (this.votingToChangeProxyInstance.methods[methodName]) {
+    if (this.instance.methods[methodName]) {
       return true
     }
     return false
   }
 
   nextBallotId() {
-    return this.votingToChangeProxyInstance.methods.nextBallotId().call()
+    return this.instance.methods.nextBallotId().call()
   }
 
   getBallotInfo(_id, _votingKey) {
     if (this.doesMethodExist('getBallotInfo')) {
-      return this.votingToChangeProxyInstance.methods.getBallotInfo(_id, _votingKey).call()
+      return this.instance.methods.getBallotInfo(_id, _votingKey).call()
     }
-    return this.votingToChangeProxyInstance.methods.votingState(_id).call()
+    return this.instance.methods.votingState(_id).call()
   }
 
   hasAlreadyVoted(_id, votingKey) {
-    return this.votingToChangeProxyInstance.methods.hasAlreadyVoted(_id, votingKey).call()
+    return this.instance.methods.hasAlreadyVoted(_id, votingKey).call()
   }
 
   isValidVote(_id, votingKey) {
-    return this.votingToChangeProxyInstance.methods.isValidVote(_id, votingKey).call()
+    return this.instance.methods.isValidVote(_id, votingKey).call()
   }
 
   isActive(_id) {
-    return this.votingToChangeProxyInstance.methods.isActive(_id).call()
+    return this.instance.methods.isActive(_id).call()
   }
 
   canBeFinalizedNow(_id) {
     if (this.doesMethodExist('canBeFinalizedNow')) {
-      return this.votingToChangeProxyInstance.methods.canBeFinalizedNow(_id).call()
+      return this.instance.methods.canBeFinalizedNow(_id).call()
     }
     return null
   }
 
   async getBallotLimit(_miningKey, _limitPerValidator) {
-    const _activeBallots = await this.votingToChangeProxyInstance.methods.validatorActiveBallots(_miningKey).call()
+    const _activeBallots = await this.instance.methods.validatorActiveBallots(_miningKey).call()
     return _limitPerValidator - _activeBallots
   }
 }

--- a/src/contracts/VotingToManageEmissionFunds.contract.js
+++ b/src/contracts/VotingToManageEmissionFunds.contract.js
@@ -1,16 +1,18 @@
 import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
+import { constants } from '../constants'
 
 export default class VotingToManageEmissionFunds {
   async init({ web3, netId }) {
-    const { VOTING_TO_MANAGE_EMISSION_FUNDS_ADDRESS } = networkAddresses(netId)
+    const { VOTING_TO_MANAGE_EMISSION_FUNDS_ADDRESS } = networkAddresses()
     console.log('VotingToManageEmissionFunds address', VOTING_TO_MANAGE_EMISSION_FUNDS_ADDRESS)
     const web3_10 = new Web3(web3.currentProvider)
 
-    const branch = helpers.getBranch(netId)
-
-    const votingToManageEmissionFundsABI = await helpers.getABI(branch, 'VotingToManageEmissionFunds')
+    const votingToManageEmissionFundsABI = await helpers.getABI(
+      constants.NETWORKS[netId].BRANCH,
+      'VotingToManageEmissionFunds'
+    )
 
     this.instance = new web3_10.eth.Contract(votingToManageEmissionFundsABI, VOTING_TO_MANAGE_EMISSION_FUNDS_ADDRESS)
     this.address = VOTING_TO_MANAGE_EMISSION_FUNDS_ADDRESS

--- a/src/contracts/VotingToManageEmissionFunds.contract.js
+++ b/src/contracts/VotingToManageEmissionFunds.contract.js
@@ -1,4 +1,3 @@
-import Web3 from 'web3'
 import { networkAddresses } from './addresses'
 import helpers from './helpers'
 import { constants } from '../constants'
@@ -7,14 +6,13 @@ export default class VotingToManageEmissionFunds {
   async init({ web3, netId }) {
     const { VOTING_TO_MANAGE_EMISSION_FUNDS_ADDRESS } = networkAddresses()
     console.log('VotingToManageEmissionFunds address', VOTING_TO_MANAGE_EMISSION_FUNDS_ADDRESS)
-    const web3_10 = new Web3(web3.currentProvider)
 
     const votingToManageEmissionFundsABI = await helpers.getABI(
       constants.NETWORKS[netId].BRANCH,
       'VotingToManageEmissionFunds'
     )
 
-    this.instance = new web3_10.eth.Contract(votingToManageEmissionFundsABI, VOTING_TO_MANAGE_EMISSION_FUNDS_ADDRESS)
+    this.instance = new web3.eth.Contract(votingToManageEmissionFundsABI, VOTING_TO_MANAGE_EMISSION_FUNDS_ADDRESS)
     this.address = VOTING_TO_MANAGE_EMISSION_FUNDS_ADDRESS
   }
 

--- a/src/contracts/addresses.js
+++ b/src/contracts/addresses.js
@@ -1,4 +1,3 @@
-import { constants } from '../constants'
 import { addressesURL, wrongRepoAlert } from './helpers'
 // const local = {
 //     VOTING_TO_CHANGE_KEYS_ADDRESS: '0xecdbe3937cf6ff27f70480855cfe03254f915b48',
@@ -9,13 +8,10 @@ import { addressesURL, wrongRepoAlert } from './helpers'
 //     POA_ADDRESS: '0xf472e0e43570b9afaab67089615080cf7c20018d',
 // }
 
-let SOKOL_ADDRESSES = {}
-let CORE_ADDRESSES = {}
-let DAI_TEST_ADDRESSES = {}
-let DAI_ADDRESSES = {}
+let ADDRESSES = {}
 
 async function getContractsAddresses(branch) {
-  let addr = addressesURL(branch)
+  const addr = addressesURL(branch)
   let response
   try {
     response = await fetch(addr)
@@ -23,43 +19,16 @@ async function getContractsAddresses(branch) {
     return wrongRepoAlert(addr)
   }
 
-  let contracts = await response.json()
+  const contracts = await response.json()
 
-  switch (branch) {
-    case 'core':
-      CORE_ADDRESSES = contracts
-      break
-    case 'dai':
-      DAI_ADDRESSES = contracts
-      break
-    case 'sokol':
-      SOKOL_ADDRESSES = contracts
-      break
-    case 'dai-test':
-      DAI_TEST_ADDRESSES = contracts
-      break
-    default:
-      CORE_ADDRESSES = contracts
-      break
-  }
+  ADDRESSES = contracts
 }
 
-function getAddresses(netId) {
-  switch (netId) {
-    case constants.NETID_SOKOL:
-      return SOKOL_ADDRESSES
-    case constants.NETID_DAI_TEST:
-      return DAI_TEST_ADDRESSES
-    case constants.NETID_CORE:
-      return CORE_ADDRESSES
-    case constants.NETID_DAI:
-      return DAI_ADDRESSES
-    default:
-      return CORE_ADDRESSES
-  }
+function networkAddresses() {
+  return ADDRESSES
 }
 
 module.exports = {
   getContractsAddresses,
-  networkAddresses: getAddresses
+  networkAddresses
 }

--- a/src/contracts/helpers.js
+++ b/src/contracts/helpers.js
@@ -27,25 +27,9 @@ function wrongRepoAlert(addr) {
   swal('Error!', messages.wrongRepo(addr), 'error')
 }
 
-function getBranch(netId) {
-  switch (netId) {
-    case constants.NETID_SOKOL:
-      return 'sokol'
-    case constants.NETID_DAI_TEST:
-      return 'dai-test'
-    case constants.NETID_CORE:
-      return 'core'
-    case constants.NETID_DAI:
-      return 'dai'
-    default:
-      return 'core'
-  }
-}
-
 module.exports = {
   addressesURL,
   ABIURL,
   getABI,
-  wrongRepoAlert,
-  getBranch
+  wrongRepoAlert
 }

--- a/src/getWeb3.js
+++ b/src/getWeb3.js
@@ -4,63 +4,75 @@ import { constants } from './constants'
 let getWeb3 = () => {
   return new Promise((resolve, reject) => {
     // Wait for loading completion to avoid race conditions with web3 injection timing.
-    window.addEventListener('load', () => {
-      var results
-      var web3 = window.web3
+    window.addEventListener('load', async () => {
+      let results
+      let web3 = window.web3
 
       // Checking if Web3 has been injected by the browser (Mist/MetaMask)
-      if (typeof web3 !== 'undefined') {
-        // Use Mist/MetaMask's provider.
-        var errorMsg = null
+      if (window.ethereum) {
+        web3 = new window.Web3(window.ethereum)
+        console.log('Injected web3 detected.')
+        try {
+          await window.ethereum.enable()
+        } catch (e) {
+          console.error('User denied account access')
+          reject({ message: messages.USER_DENIED_ACCOUNT_ACCESS })
+          return
+        }
+      } else if (typeof web3 !== 'undefined') {
         web3 = new window.Web3(web3.currentProvider)
-        web3.version.getNetwork((err, netId) => {
-          let netIdName
-          console.log('netId', netId)
-          switch (netId) {
-            case constants.NETID_DAI:
-              netIdName = 'Dai'
-              console.log('This is Dai', netId)
-              break
-            case constants.NETID_CORE:
-              netIdName = 'Core'
-              console.log('This is Core', netId)
-              break
-            case constants.NETID_DAI_TEST:
-              netIdName = 'Dai-Test'
-              console.log('This is Dai-Test', netId)
-              break
-            case constants.NETID_SOKOL:
-              netIdName = 'Sokol'
-              console.log('This is Sokol', netId)
-              break
-            default:
-              netIdName = 'ERROR'
-              errorMsg = messages.WRONG_NETWORK_MSG
-              console.log('This is an unknown network.', netId)
-          }
-          document.title = `${netIdName} - POA Network Governance DApp`
-          var defaultAccount = web3.eth.defaultAccount || null
-          if (defaultAccount === null) {
-            reject({ message: messages.NO_METAMASK_MSG })
-          }
-          if (errorMsg !== null) {
-            reject({ message: errorMsg })
-          }
-          results = {
-            web3Instance: web3,
-            netIdName,
-            netId,
-            injectedWeb3: true,
-            defaultAccount
-          }
-          resolve(results)
-        })
-
         console.log('Injected web3 detected.')
       } else {
-        reject({ message: messages.NO_METAMASK_MSG })
         console.error('Metamask not found')
+        reject({ message: messages.NO_METAMASK_MSG })
+        return
       }
+
+      let errorMsg = null
+      web3.version.getNetwork((err, netId) => {
+        let netIdName
+        console.log('netId', netId)
+        switch (netId) {
+          case constants.NETID_DAI:
+            netIdName = 'Dai'
+            console.log('This is Dai', netId)
+            break
+          case constants.NETID_CORE:
+            netIdName = 'Core'
+            console.log('This is Core', netId)
+            break
+          case constants.NETID_DAI_TEST:
+            netIdName = 'Dai-Test'
+            console.log('This is Dai-Test', netId)
+            break
+          case constants.NETID_SOKOL:
+            netIdName = 'Sokol'
+            console.log('This is Sokol', netId)
+            break
+          default:
+            netIdName = 'ERROR'
+            errorMsg = messages.WRONG_NETWORK_MSG
+            console.log('This is an unknown network.', netId)
+        }
+        document.title = `${netIdName} - POA Network Governance DApp`
+        if (errorMsg !== null) {
+          reject({ message: errorMsg })
+          return
+        }
+        var defaultAccount = web3.eth.defaultAccount || null
+        if (defaultAccount === null) {
+          reject({ message: messages.NO_METAMASK_MSG })
+          return
+        }
+        results = {
+          web3Instance: web3,
+          netIdName,
+          netId,
+          injectedWeb3: true,
+          defaultAccount
+        }
+        resolve(results)
+      })
     })
   })
 }

--- a/src/getWeb3.js
+++ b/src/getWeb3.js
@@ -1,3 +1,4 @@
+import Web3 from 'web3'
 import { messages } from './messages'
 import { constants } from './constants'
 
@@ -9,7 +10,7 @@ let getWeb3 = () => {
 
       // Checking if Web3 has been injected by the browser (Mist/MetaMask)
       if (window.ethereum) {
-        web3 = new window.Web3(window.ethereum)
+        web3 = new Web3(window.ethereum)
         console.log('Injected web3 detected.')
         try {
           await window.ethereum.enable()
@@ -19,7 +20,7 @@ let getWeb3 = () => {
           return
         }
       } else if (typeof window.web3 !== 'undefined') {
-        web3 = new window.Web3(window.web3.currentProvider)
+        web3 = new Web3(window.web3.currentProvider)
         console.log('Injected web3 detected.')
       } else {
         console.error('Metamask not found')
@@ -27,40 +28,41 @@ let getWeb3 = () => {
         return
       }
 
-      web3.version.getNetwork((err, netId) => {
-        let netIdName
-        let errorMsg = null
+      const netId = await web3.eth.net.getId()
+      console.log('netId', netId)
 
-        console.log('netId', netId)
+      let netIdName
+      let errorMsg = null
 
-        if (netId in constants.NETWORKS) {
-          netIdName = constants.NETWORKS[netId].NAME
-          console.log(`This is ${netIdName}`)
-        } else {
-          netIdName = 'ERROR'
-          errorMsg = messages.WRONG_NETWORK_MSG
-          console.log('This is an unknown network.')
-        }
+      if (netId in constants.NETWORKS) {
+        netIdName = constants.NETWORKS[netId].NAME
+        console.log(`This is ${netIdName}`)
+      } else {
+        netIdName = 'ERROR'
+        errorMsg = messages.WRONG_NETWORK_MSG
+        console.log('This is an unknown network.')
+      }
 
-        document.title = `${netIdName} - POA Network Governance DApp`
+      document.title = `${netIdName} - POA Network Governance DApp`
 
-        if (errorMsg !== null) {
-          reject({ message: errorMsg })
-          return
-        }
+      if (errorMsg !== null) {
+        reject({ message: errorMsg })
+        return
+      }
 
-        var defaultAccount = web3.eth.defaultAccount || null
-        if (defaultAccount === null) {
-          reject({ message: messages.NO_METAMASK_MSG })
-          return
-        }
+      const accounts = await web3.eth.getAccounts()
 
-        resolve({
-          web3Instance: web3,
-          netIdName,
-          netId,
-          defaultAccount
-        })
+      var defaultAccount = accounts[0] || null
+      if (defaultAccount === null) {
+        reject({ message: messages.NO_METAMASK_MSG })
+        return
+      }
+
+      resolve({
+        web3Instance: web3,
+        netIdName,
+        netId,
+        defaultAccount
       })
     })
   })

--- a/src/getWeb3.js
+++ b/src/getWeb3.js
@@ -5,8 +5,7 @@ let getWeb3 = () => {
   return new Promise((resolve, reject) => {
     // Wait for loading completion to avoid race conditions with web3 injection timing.
     window.addEventListener('load', async () => {
-      let results
-      let web3 = window.web3
+      let web3
 
       // Checking if Web3 has been injected by the browser (Mist/MetaMask)
       if (window.ethereum) {
@@ -19,8 +18,8 @@ let getWeb3 = () => {
           reject({ message: messages.USER_DENIED_ACCOUNT_ACCESS })
           return
         }
-      } else if (typeof web3 !== 'undefined') {
-        web3 = new window.Web3(web3.currentProvider)
+      } else if (typeof window.web3 !== 'undefined') {
+        web3 = new window.Web3(window.web3.currentProvider)
         console.log('Injected web3 detected.')
       } else {
         console.error('Metamask not found')
@@ -28,50 +27,40 @@ let getWeb3 = () => {
         return
       }
 
-      let errorMsg = null
       web3.version.getNetwork((err, netId) => {
         let netIdName
+        let errorMsg = null
+
         console.log('netId', netId)
-        switch (netId) {
-          case constants.NETID_DAI:
-            netIdName = 'Dai'
-            console.log('This is Dai', netId)
-            break
-          case constants.NETID_CORE:
-            netIdName = 'Core'
-            console.log('This is Core', netId)
-            break
-          case constants.NETID_DAI_TEST:
-            netIdName = 'Dai-Test'
-            console.log('This is Dai-Test', netId)
-            break
-          case constants.NETID_SOKOL:
-            netIdName = 'Sokol'
-            console.log('This is Sokol', netId)
-            break
-          default:
-            netIdName = 'ERROR'
-            errorMsg = messages.WRONG_NETWORK_MSG
-            console.log('This is an unknown network.', netId)
+
+        if (netId in constants.NETWORKS) {
+          netIdName = constants.NETWORKS[netId].NAME
+          console.log(`This is ${netIdName}`)
+        } else {
+          netIdName = 'ERROR'
+          errorMsg = messages.WRONG_NETWORK_MSG
+          console.log('This is an unknown network.')
         }
+
         document.title = `${netIdName} - POA Network Governance DApp`
+
         if (errorMsg !== null) {
           reject({ message: errorMsg })
           return
         }
+
         var defaultAccount = web3.eth.defaultAccount || null
         if (defaultAccount === null) {
           reject({ message: messages.NO_METAMASK_MSG })
           return
         }
-        results = {
+
+        resolve({
           web3Instance: web3,
           netIdName,
           netId,
-          injectedWeb3: true,
           defaultAccount
-        }
-        resolve(results)
+        })
       })
     })
   })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,3 @@
-import Web3 from 'web3'
 import swal from 'sweetalert2'
 import { constants } from './constants'
 
@@ -23,7 +22,7 @@ function sleep(ms) {
 
 function sendTransactionByVotingKey(props, to, data, cb, warning) {
   const { commonStore, contractsStore } = props
-  const web3 = new Web3(contractsStore.web3Instance.currentProvider)
+  const web3 = contractsStore.web3Instance
 
   web3.eth.sendTransaction(
     {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -59,12 +59,7 @@ function sendTransactionByVotingKey(props, to, data, cb, warning) {
   )
 }
 
-function isTestnet(netId) {
-  return netId === constants.NETID_SOKOL || netId === constants.NETID_DAI_TEST
-}
-
 module.exports = {
   toAscii,
-  sendTransactionByVotingKey,
-  isTestnet
+  sendTransactionByVotingKey
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ import ballotStore from './stores/BallotStore'
 import ballotsStore from './stores/BallotsStore'
 import contractsStore from './stores/ContractsStore'
 import { getContractsAddresses } from './contracts/addresses'
-import { getBranch } from './contracts/helpers'
 import swal from 'sweetalert2'
 import getWeb3 from './getWeb3'
 import 'babel-polyfill'
@@ -35,7 +34,7 @@ class AppMainRouter extends Component {
 
     getWeb3()
       .then(async web3Config => {
-        await getContractsAddresses(getBranch(web3Config.netId))
+        await getContractsAddresses(constants.NETWORKS[web3Config.netId].BRANCH)
 
         contractsStore.setWeb3Instance(web3Config)
 
@@ -48,7 +47,7 @@ class AppMainRouter extends Component {
         const setVotingToChangeProxy = contractsStore.setVotingToChangeProxy(web3Config)
         const setValidatorMetadata = contractsStore.setValidatorMetadata(web3Config)
 
-        const promises = [
+        let promises = [
           setPoaConsensus,
           setBallotsStorage,
           setKeysManager,
@@ -59,8 +58,9 @@ class AppMainRouter extends Component {
           setValidatorMetadata
         ]
 
-        if (web3Config.netId === constants.NETID_SOKOL) {
-          // if we're in Sokol
+        const networkName = constants.NETWORKS[web3Config.netId].NAME.toLowerCase()
+        if (networkName === 'core' || networkName === 'sokol') {
+          // if we're in Core or Sokol
           promises.push(contractsStore.setEmissionFunds(web3Config))
           promises.push(contractsStore.setVotingToManageEmissionFunds(web3Config))
         }

--- a/src/messages.js
+++ b/src/messages.js
@@ -15,6 +15,7 @@ messages.MINING_KEY_IS_NOT_ADDRESS_MSG = "Ballot miningKey isn't address"
 messages.PROPOSED_ADDRESS_IS_NOT_ADDRESS_MSG = "Proposed address isn't address"
 messages.END_TIME_SHOULD_BE_GREATER_THAN_NOW_MSG = 'Ballot end time should be greater than now'
 messages.BALLOT_TYPE_IS_EMPTY_MSG = 'Ballot type is empty'
+messages.USER_DENIED_ACCOUNT_ACCESS = 'You have denied access to your accounts'
 messages.NO_METAMASK_MSG = `You haven't chosen any account in MetaMask.
 Please, choose your voting key in MetaMask and reload the page.
 Check POA Network <a href='https://github.com/poanetwork/wiki' target='blank'>wiki</a> for more info.`

--- a/src/stores/ContractsStore.js
+++ b/src/stores/ContractsStore.js
@@ -61,13 +61,13 @@ class ContractsStore {
 
   @action('Get keys ballot threshold')
   getKeysBallotThreshold = async () => {
-    this.keysBallotThreshold = await this.ballotsStorage.ballotsStorageInstance.methods.getBallotThreshold(1).call()
+    this.keysBallotThreshold = await this.ballotsStorage.instance.methods.getBallotThreshold(1).call()
     this.minThresholdBallotThreshold = this.keysBallotThreshold
   }
 
   @action('Get proxy ballot threshold')
   getProxyBallotThreshold = async () => {
-    this.proxyBallotThreshold = await this.ballotsStorage.ballotsStorageInstance.methods.getProxyThreshold().call()
+    this.proxyBallotThreshold = await this.ballotsStorage.instance.methods.getProxyThreshold().call()
     this.emissionFundsBallotThreshold = this.proxyBallotThreshold
   }
 
@@ -176,7 +176,7 @@ class ContractsStore {
 
   @action('Get validators length')
   getValidatorsLength = async () => {
-    this.validatorsLength = await this.poaConsensus.poaInstance.methods.getCurrentValidatorsLength().call()
+    this.validatorsLength = await this.poaConsensus.instance.methods.getCurrentValidatorsLength().call()
   }
 
   @action('Set voting key')
@@ -389,9 +389,7 @@ class ContractsStore {
   @action
   async getBallotsLimits() {
     if (this.web3Instance && this.netId) {
-      const limitPerValidator = await this.ballotsStorage.ballotsStorageInstance.methods
-        .getBallotLimitPerValidator()
-        .call()
+      const limitPerValidator = await this.ballotsStorage.instance.methods.getBallotLimitPerValidator().call()
 
       let getKeysLimit = await this.votingToChangeKeys.getBallotLimit(this.miningKey, limitPerValidator)
       let getMinThresholdLimit = await this.votingToChangeMinThreshold.getBallotLimit(this.miningKey, limitPerValidator)


### PR DESCRIPTION
- (Mandatory) Description

    This PR solves the issue https://github.com/poanetwork/poa-dapps-voting/issues/179 and makes some refactoring of code. MetaMask v4.14.0 (and above) will display the next confirmation message when a user opens DApp for the first time after `November 2nd, 2018`:

    ![image](https://user-images.githubusercontent.com/33550681/46724947-c0123180-cc83-11e8-8d0f-fc881ac48b24.png)
    
    If the user clicks on `Approve`, the DApp will load and continue working. Otherwise (in the case of `Reject`), DApp will show the next alert and stop execution:

    ![image](https://user-images.githubusercontent.com/33550681/46725153-3ca51000-cc84-11e8-8655-560ceb739dd8.png)

    If the user clicks on `Approve`, MetaMask will cache user's choice and won't ask the user again next time until he/ she clears approval data in MetaMask's settings.

    The custom build of MetaMask for testing can be downloaded here: https://github.com/MetaMask/metamask-extension/pull/4703#issuecomment-427062852.

    These changes are backward compatible, so the new code will work fine with old DApp browsers that don't support `ethereum.enable()` feature yet.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix, Refactor)