### PR TITLE
(Feature) Display Core ballots by default if MetaMask is not installed

### DIFF
--- a/src/components/BallotCard.jsx
+++ b/src/components/BallotCard.jsx
@@ -295,7 +295,10 @@ export class BallotCard extends React.Component {
     }
     const { commonStore, contractsStore, id, votingType, ballotsStore, pos } = this.props
     const { push } = this.props.routing
-    if (!contractsStore.isValidVotingKey) {
+    if (!contractsStore.votingKey) {
+      swal('Warning!', messages.NO_METAMASK_MSG, 'warning')
+      return
+    } else if (!contractsStore.isValidVotingKey) {
       swal('Warning!', messages.invalidVotingKeyMsg(contractsStore.votingKey), 'warning')
       return
     }
@@ -431,7 +434,10 @@ export class BallotCard extends React.Component {
     }
     const { commonStore, contractsStore, id, votingType, ballotsStore, pos } = this.props
     const { push } = this.props.routing
-    if (!contractsStore.isValidVotingKey) {
+    if (!contractsStore.votingKey) {
+      swal('Warning!', messages.NO_METAMASK_MSG, 'warning')
+      return
+    } else if (!contractsStore.isValidVotingKey) {
       swal('Warning!', messages.invalidVotingKeyMsg(contractsStore.votingKey), 'warning')
       return
     }

--- a/src/components/NewBallot.jsx
+++ b/src/components/NewBallot.jsx
@@ -237,13 +237,14 @@ export class NewBallot extends React.Component {
   onClick = async () => {
     const { commonStore, contractsStore, ballotStore, ballotsStore } = this.props
     const { push } = this.props.routing
-    commonStore.showLoading()
-    const isValidVotingKey = contractsStore.isValidVotingKey
-    if (!isValidVotingKey) {
-      commonStore.hideLoading()
+    if (!contractsStore.votingKey) {
+      swal('Warning!', messages.NO_METAMASK_MSG, 'warning')
+      return
+    } else if (!contractsStore.isValidVotingKey) {
       swal('Warning!', messages.invalidVotingKeyMsg(contractsStore.votingKey), 'warning')
       return
     }
+    commonStore.showLoading()
     const isFormValid = this.checkValidation()
     if (isFormValid) {
       if (ballotStore.ballotType === ballotStore.BallotType.keys) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,21 +28,25 @@ constants.getTransactionReceiptInterval = 5000
 constants.NETWORKS = {
   '77': {
     NAME: 'Sokol',
+    RPC: 'https://sokol.poa.network',
     BRANCH: 'sokol',
     TESTNET: true
   },
   '99': {
     NAME: 'Core',
+    RPC: 'https://core.poa.network',
     BRANCH: 'core',
     TESTNET: false
   },
   '79': {
     NAME: 'Dai-Test',
+    RPC: 'https://dai-test.poa.network',
     BRANCH: 'dai-test',
     TESTNET: true
   },
   '100': {
     NAME: 'Dai',
+    RPC: 'https://dai.poa.network',
     BRANCH: 'dai',
     TESTNET: false
   }

--- a/src/getWeb3.js
+++ b/src/getWeb3.js
@@ -1,12 +1,13 @@
 import Web3 from 'web3'
 import { messages } from './messages'
 import { constants } from './constants'
+import { netIdByName } from './helpers'
 
 let getWeb3 = () => {
   return new Promise((resolve, reject) => {
     // Wait for loading completion to avoid race conditions with web3 injection timing.
     window.addEventListener('load', async () => {
-      let web3
+      let web3 = null
 
       // Checking if Web3 has been injected by the browser (Mist/MetaMask)
       if (window.ethereum) {
@@ -22,39 +23,47 @@ let getWeb3 = () => {
       } else if (typeof window.web3 !== 'undefined') {
         web3 = new Web3(window.web3.currentProvider)
         console.log('Injected web3 detected.')
-      } else {
-        console.error('Metamask not found')
-        reject({ message: messages.NO_METAMASK_MSG })
-        return
       }
 
-      const netId = await web3.eth.net.getId()
-      console.log('netId', netId)
-
-      let netIdName
       let errorMsg = null
+      let netIdName
+      let netId
+      let defaultAccount = null
 
-      if (netId in constants.NETWORKS) {
-        netIdName = constants.NETWORKS[netId].NAME
-        console.log(`This is ${netIdName}`)
+      if (web3) {
+        netId = await web3.eth.net.getId()
+        console.log('netId', netId)
+
+        if (!(netId in constants.NETWORKS)) {
+          netIdName = 'ERROR'
+          errorMsg = messages.WRONG_NETWORK_MSG
+          console.log('This is an unknown network.')
+        } else {
+          netIdName = constants.NETWORKS[netId].NAME
+          console.log(`This is ${netIdName}`)
+        }
+
+        const accounts = await web3.eth.getAccounts()
+
+        defaultAccount = accounts[0] || null
       } else {
-        netIdName = 'ERROR'
-        errorMsg = messages.WRONG_NETWORK_MSG
-        console.log('This is an unknown network.')
+        // Fallback to local if no web3 injection.
+
+        console.log('No web3 instance injected, using Local web3.')
+        console.error('Metamask not found')
+
+        netId = netIdByName('core')
+
+        const network = constants.NETWORKS[netId]
+
+        web3 = new Web3(new Web3.providers.HttpProvider(network.RPC))
+        netIdName = network.NAME
       }
 
       document.title = `${netIdName} - POA Network Governance DApp`
 
       if (errorMsg !== null) {
         reject({ message: errorMsg })
-        return
-      }
-
-      const accounts = await web3.eth.getAccounts()
-
-      var defaultAccount = accounts[0] || null
-      if (defaultAccount === null) {
-        reject({ message: messages.NO_METAMASK_MSG })
         return
       }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -58,7 +58,18 @@ function sendTransactionByVotingKey(props, to, data, cb, warning) {
   )
 }
 
+function netIdByName(netName) {
+  const netNameLowerCase = netName.toLowerCase()
+  for (let netId in constants.NETWORKS) {
+    if (constants.NETWORKS[netId].NAME.toLowerCase() === netNameLowerCase) {
+      return netId
+    }
+  }
+  return null
+}
+
 module.exports = {
   toAscii,
-  sendTransactionByVotingKey
+  sendTransactionByVotingKey,
+  netIdByName
 }


### PR DESCRIPTION
- (Mandatory) Description
Partially solves the issue https://github.com/poanetwork/poa-dapps-voting/issues/185. After this PR is merged, the Voting DApp will begin to display all ballots for `Core` network if MetaMask is not installed. Network switching (as in Validators DApp) will be added later.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Feature)