### PR TITLE
(Feature) Add `RewardByBlock` item to drop-down list on the page `Modify Proxy Contract Ballot` for Sokol network

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -87,7 +87,7 @@ class App extends Component {
 
   getNetIdClass() {
     const { netId } = this.props.contractsStore
-    return netId in constants.NETWORKS && constants.NETWORKS[netId].TESTNET ? 'sokol' : ''
+    return netId in constants.NETWORKS && constants.NETWORKS[netId].TESTNET ? constants.SOKOL : ''
   }
 
   isNewBallotPage() {

--- a/src/components/BallotEmissionFundsMetadata/index.js
+++ b/src/components/BallotEmissionFundsMetadata/index.js
@@ -72,7 +72,7 @@ export class BallotEmissionFundsMetadata extends React.Component {
 
   render() {
     const { ballotStore, contractsStore, networkBranch } = this.props
-    let note, explorerLink
+    let note
 
     if (this.noActiveBallotExists === true) {
       note = (
@@ -85,11 +85,8 @@ export class BallotEmissionFundsMetadata extends React.Component {
       note = <p>To be able to create a new ballot, the previous ballot of this type must be finalized.</p>
     }
 
-    if (constants.NETWORKS[contractsStore.netId].NAME.toLowerCase() === 'sokol') {
-      explorerLink = `https://sokol.poaexplorer.com/address/search/${contractsStore.emissionFunds.address}`
-    } else {
-      explorerLink = `https://poaexplorer.com/address/${contractsStore.emissionFunds.address}`
-    }
+    const networkName = constants.NETWORKS[contractsStore.netId].NAME.toLowerCase()
+    const explorerLink = `https://blockscout.com/poa/${networkName}/address/${contractsStore.emissionFunds.address}`
 
     return (
       <div className="frm-BallotEmissionFundsMetadata">

--- a/src/components/BallotProxyMetadata/index.js
+++ b/src/components/BallotProxyMetadata/index.js
@@ -2,23 +2,28 @@ import React from 'react'
 import { FormInput } from '../FormInput'
 import { FormSelect } from '../FormSelect'
 import { inject, observer } from 'mobx-react'
+import { getNetworkName } from '../../utils/utils'
 
 @inject('ballotStore', 'contractsStore')
 @observer
 export class BallotProxyMetadata extends React.Component {
   render() {
-    const { ballotStore, networkBranch } = this.props
+    const { ballotStore, contractsStore, networkBranch } = this.props
     let options = [
-      { value: '', label: '' },
-      { value: '1', label: ballotStore.ProxyBallotType[1] }, // KeysManager
-      { value: '2', label: ballotStore.ProxyBallotType[2] }, // VotingToChangeKeys
-      { value: '3', label: ballotStore.ProxyBallotType[3] }, // VotingToChangeMinThreshold
-      { value: '4', label: ballotStore.ProxyBallotType[4] }, // VotingToChangeProxy
-      { value: '5', label: ballotStore.ProxyBallotType[5] }, // BallotsStorage
-      { value: '7', label: ballotStore.ProxyBallotType[7] }, // ValidatorMetadata
-      { value: '8', label: ballotStore.ProxyBallotType[8] }, // ProxyStorage
-      { value: '9', label: ballotStore.ProxyBallotType[9] } // RewardByBlock
+      /*0*/ { value: '', label: '' },
+      /*1*/ { value: '1', label: ballotStore.ProxyBallotType[1] }, // KeysManager
+      /*2*/ { value: '2', label: ballotStore.ProxyBallotType[2] }, // VotingToChangeKeys
+      /*3*/ { value: '3', label: ballotStore.ProxyBallotType[3] }, // VotingToChangeMinThreshold
+      /*4*/ { value: '4', label: ballotStore.ProxyBallotType[4] }, // VotingToChangeProxy
+      /*5*/ { value: '5', label: ballotStore.ProxyBallotType[5] }, // BallotsStorage
+      /*6*/ { value: '7', label: ballotStore.ProxyBallotType[7] }, // ValidatorMetadata
+      /*7*/ { value: '8', label: ballotStore.ProxyBallotType[8] }, // ProxyStorage
+      /*8*/ { value: '9', label: ballotStore.ProxyBallotType[9] } // RewardByBlock
     ]
+
+    if (getNetworkName(contractsStore.netId).toLowerCase() != 'sokol') {
+      options.splice(8) // keep 0-7 items and remove 8th if the network is not Sokol
+    }
 
     return (
       <div className="frm-BallotProxyMetadata">

--- a/src/components/BallotProxyMetadata/index.js
+++ b/src/components/BallotProxyMetadata/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormInput } from '../FormInput'
 import { FormSelect } from '../FormSelect'
 import { inject, observer } from 'mobx-react'
+import { constants } from '../../utils/constants'
 import { getNetworkName } from '../../utils/utils'
 
 @inject('ballotStore', 'contractsStore')
@@ -21,7 +22,7 @@ export class BallotProxyMetadata extends React.Component {
       /*8*/ { value: '9', label: ballotStore.ProxyBallotType[9] } // RewardByBlock
     ]
 
-    if (getNetworkName(contractsStore.netId).toLowerCase() != 'sokol') {
+    if (getNetworkName(contractsStore.netId).toLowerCase() !== constants.SOKOL) {
       options.splice(8) // keep 0-7 items and remove 8th if the network is not Sokol
     }
 

--- a/src/components/BallotProxyMetadata/index.js
+++ b/src/components/BallotProxyMetadata/index.js
@@ -7,21 +7,18 @@ import { inject, observer } from 'mobx-react'
 @observer
 export class BallotProxyMetadata extends React.Component {
   render() {
-    const { ballotStore, contractsStore, networkBranch } = this.props
+    const { ballotStore, networkBranch } = this.props
     let options = [
-      /*0*/ { value: '', label: '' },
-      /*1*/ { value: '1', label: ballotStore.ProxyBallotType[1] }, // KeysManager
-      /*2*/ { value: '2', label: ballotStore.ProxyBallotType[2] }, // VotingToChangeKeys
-      /*3*/ { value: '3', label: ballotStore.ProxyBallotType[3] }, // VotingToChangeMinThreshold
-      /*4*/ { value: '4', label: ballotStore.ProxyBallotType[4] }, // VotingToChangeProxy
-      /*5*/ { value: '5', label: ballotStore.ProxyBallotType[5] }, // BallotsStorage
-      /*6*/ { value: '7', label: ballotStore.ProxyBallotType[7] }, // ValidatorMetadata
-      /*7*/ { value: '8', label: ballotStore.ProxyBallotType[8] } // ProxyStorage
+      { value: '', label: '' },
+      { value: '1', label: ballotStore.ProxyBallotType[1] }, // KeysManager
+      { value: '2', label: ballotStore.ProxyBallotType[2] }, // VotingToChangeKeys
+      { value: '3', label: ballotStore.ProxyBallotType[3] }, // VotingToChangeMinThreshold
+      { value: '4', label: ballotStore.ProxyBallotType[4] }, // VotingToChangeProxy
+      { value: '5', label: ballotStore.ProxyBallotType[5] }, // BallotsStorage
+      { value: '7', label: ballotStore.ProxyBallotType[7] }, // ValidatorMetadata
+      { value: '8', label: ballotStore.ProxyBallotType[8] }, // ProxyStorage
+      { value: '9', label: ballotStore.ProxyBallotType[9] } // RewardByBlock
     ]
-
-    if (!contractsStore.proxyStorage || !contractsStore.proxyStorage.doesMethodExist('getValidatorMetadata')) {
-      options.splice(6) // keep 0-5 and remove 6-... items if ProxyStorage is old
-    }
 
     return (
       <div className="frm-BallotProxyMetadata">

--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -2,15 +2,14 @@ import React from 'react'
 import { LogoPOA } from '../LogoPOA'
 import { LogoSokol } from '../LogoSokol'
 import { LogoDai } from '../LogoDai'
+import { constants } from '../../utils/constants'
 
 export const Logo = ({ href = null, extraClass = '', networkBranch = '' }) => {
   switch (networkBranch) {
-    case 'sokol':
+    case constants.SOKOL:
       return <LogoSokol href={href} extraClass={extraClass} />
-    case 'dai':
-    case 'dai-test':
+    case constants.DAI:
       return <LogoDai href={href} extraClass={extraClass} />
-    case 'poa':
     default:
       return <LogoPOA href={href} extraClass={extraClass} />
   }

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ class AppMainRouter extends Component {
         ]
 
         const networkName = constants.NETWORKS[web3Config.netId].NAME.toLowerCase()
-        if (networkName === 'core' || networkName === 'sokol') {
+        if (networkName === constants.CORE || networkName === constants.SOKOL) {
           // if we're in Core or Sokol
           promises.push(contractsStore.setEmissionFunds(web3Config))
           promises.push(contractsStore.setVotingToManageEmissionFunds(web3Config))

--- a/src/stores/BallotStore.js
+++ b/src/stores/BallotStore.js
@@ -26,7 +26,8 @@ class BallotStore {
     4: 'VotingToChangeProxy',
     5: 'BallotsStorage',
     7: 'ValidatorMetadata',
-    8: 'ProxyStorage'
+    8: 'ProxyStorage',
+    9: 'RewardByBlock'
   }
   @observable ballotType
   @observable keysBallotType

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -51,23 +51,27 @@ constants.navigationData = [
   }
 ]
 
+constants.SOKOL = 'sokol'
+constants.CORE = 'core'
+constants.DAI = 'dai'
+
 constants.NETWORKS = {
   '77': {
     NAME: 'Sokol',
     RPC: 'https://sokol.poa.network',
-    BRANCH: 'sokol',
+    BRANCH: constants.SOKOL,
     TESTNET: true
   },
   '99': {
     NAME: 'Core',
     RPC: 'https://core.poa.network',
-    BRANCH: 'core',
+    BRANCH: constants.CORE,
     TESTNET: false
   },
   '100': {
     NAME: 'Dai',
     RPC: 'https://dai.poa.network',
-    BRANCH: 'dai',
+    BRANCH: constants.DAI,
     TESTNET: false
   }
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -64,12 +64,6 @@ constants.NETWORKS = {
     BRANCH: 'core',
     TESTNET: false
   },
-  '79': {
-    NAME: 'Dai-Test',
-    RPC: 'https://dai-test.poa.network',
-    BRANCH: 'dai-test',
-    TESTNET: true
-  },
   '100': {
     NAME: 'Dai',
     RPC: 'https://dai.poa.network',

--- a/src/utils/getWeb3.js
+++ b/src/utils/getWeb3.js
@@ -52,7 +52,7 @@ let getWeb3 = () => {
         console.log('No web3 instance injected, using Local web3.')
         console.error('Metamask not found')
 
-        netId = netIdByName('core')
+        netId = netIdByName(constants.CORE)
 
         const network = constants.NETWORKS[netId]
 


### PR DESCRIPTION
- (Mandatory) Description
    These changes are for displaying `RewardByBlock` item in the drop-down list on the page `Modify Proxy Contract Ballot` for Sokol network. Should be merged after `Proxy Ballot #1` in `Sokol` is finalized by validators. Related to https://github.com/poanetwork/poa-network-consensus-contracts/pull/205.

    ![image](https://user-images.githubusercontent.com/33550681/51764004-fcf41e00-20e4-11e9-9712-f38c89906441.png)

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Feature)