### PR TITLE
(Feature) Allow displaying `RewardByBlock` item in drop-down list on the page `Modify Proxy Contract Ballot` for all networks

### DIFF
--- a/src/components/BallotProxyMetadata/index.js
+++ b/src/components/BallotProxyMetadata/index.js
@@ -22,12 +22,6 @@ export class BallotProxyMetadata extends React.Component {
       /*8*/ { value: '9', label: ballotStore.ProxyBallotType[9] } // RewardByBlock
     ]
 
-    const networkName = getNetworkName(contractsStore.netId).toLowerCase()
-
-    if (networkName !== constants.SOKOL && networkName !== constants.DAI) {
-      options.splice(8) // keep 0-7 items and remove 8th if the network is not Sokol or xDai
-    }
-
     return (
       <div className="frm-BallotProxyMetadata">
         <div className="frm-BallotProxyMetadata_Row">


### PR DESCRIPTION
- (Mandatory) Description

    These changes are for displaying `RewardByBlock` item in the drop-down list on the page `Modify Proxy Contract Ballot` for `Core`, `Sokol`, or `xDai` network. Related to https://github.com/poanetwork/poa-network-consensus-contracts/pull/205, https://github.com/poanetwork/poa-dapps-voting/pull/194, https://github.com/poanetwork/poa-dapps-voting/pull/196.

    Should only be merged after the `Proxy Ballot #0` in `Core` network is finalized.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Feature)