### PR TITLE
(Fix) Temporarily remove Validator fields from the `New Ballot` page

### DIFF
--- a/src/components/NewBallot/index.js
+++ b/src/components/NewBallot/index.js
@@ -42,15 +42,16 @@ export class NewBallot extends React.Component {
   checkValidation() {
     const { commonStore, contractsStore, ballotStore, validatorStore } = this.props
 
-    if (ballotStore.isNewValidatorPersonalData) {
-      for (let validatorProp in validatorStore) {
-        if (validatorStore[validatorProp].length === 0) {
-          swal('Warning!', `Validator ${validatorProp} is empty`, 'warning')
-          commonStore.hideLoading()
-          return false
-        }
-      }
-    }
+    // Temporarily commented (until we implement https://github.com/poanetwork/poa-dapps-voting/issues/120)
+    // if (ballotStore.isNewValidatorPersonalData) {
+    //   for (let validatorProp in validatorStore) {
+    //     if (validatorStore[validatorProp].length === 0) {
+    //       swal('Warning!', `Validator ${validatorProp} is empty`, 'warning')
+    //       commonStore.hideLoading()
+    //       return false
+    //     }
+    //   }
+    // }
 
     if (!ballotStore.memo) {
       swal('Warning!', messages.DESCRIPTION_IS_EMPTY, 'warning')

--- a/src/components/Validator/index.js
+++ b/src/components/Validator/index.js
@@ -63,6 +63,7 @@ export class Validator extends React.Component {
   }
 
   render() {
+    return null // Temporarily empty (until we implement https://github.com/poanetwork/poa-dapps-voting/issues/120)
     const { validatorStore, networkBranch } = this.props
     const inputProps = {
       value: validatorStore.address,


### PR DESCRIPTION
- (Mandatory) Description
This PR hides the validator fields from the `New Ballot` page when creating a ballot for adding new mining key since we don't use them. Relates to https://github.com/poanetwork/poa-dapps-voting/issues/120 and https://github.com/poanetwork/poa-dapps-voting/issues/188.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)