### PR TITLE
(Fix) a bug in displaying Proposer field

### DIFF
--- a/src/stores/ContractsStore.js
+++ b/src/stores/ContractsStore.js
@@ -413,9 +413,9 @@ class ContractsStore {
     keys.forEach(async key => {
       const metadata = await this.validatorMetadata.getValidatorFullName(key)
       this.validatorsMetadata[key.toLowerCase()] = {
-        label: `${key} ${metadata.lastName}`,
-        lastNameAndKey: `${metadata.lastName} ${key}`,
-        fullName: `${metadata.firstName} ${metadata.lastName}`,
+        label: `${key} ${metadata.lastName}`.trim(),
+        lastNameAndKey: `${metadata.lastName} ${key}`.trim(),
+        fullName: `${metadata.firstName} ${metadata.lastName}`.trim(),
         value: key
       }
     })


### PR DESCRIPTION
- (Mandatory) Description

    If a ballot proposer has no metadata yet, the `Proposer` field is empty instead of displaying proposer's mining key. This PR fixes that.

<img src="https://user-images.githubusercontent.com/33550681/57832458-65fcc000-77c0-11e9-93f2-98c87e9b46d7.png" height="300" />

- (Mandatory) What is it: (Fix), (Feature), or (Refactor) in Title
(Fix)