### PR TITLE
(Fix) a bug in displaying a text note near the Finalize button

### DIFF
--- a/src/contracts/VotingToChangeKeys.contract.js
+++ b/src/contracts/VotingToChangeKeys.contract.js
@@ -85,4 +85,8 @@ export default class VotingToChangeKeys {
     const _activeBallots = await this.instance.methods.validatorActiveBallots(_miningKey).call()
     return _limitPerValidator - _activeBallots
   }
+
+  async minBallotDuration() {
+    return await this.instance.methods.minBallotDuration().call()
+  }
 }

--- a/src/contracts/VotingToChangeMinThreshold.contract.js
+++ b/src/contracts/VotingToChangeMinThreshold.contract.js
@@ -77,4 +77,8 @@ export default class VotingToChangeMinThreshold {
     const _activeBallots = await this.instance.methods.validatorActiveBallots(_miningKey).call()
     return _limitPerValidator - _activeBallots
   }
+
+  async minBallotDuration() {
+    return await this.instance.methods.minBallotDuration().call()
+  }
 }

--- a/src/contracts/VotingToChangeProxy.contract.js
+++ b/src/contracts/VotingToChangeProxy.contract.js
@@ -73,4 +73,8 @@ export default class VotingToChangeProxy {
     const _activeBallots = await this.instance.methods.validatorActiveBallots(_miningKey).call()
     return _limitPerValidator - _activeBallots
   }
+
+  async minBallotDuration() {
+    return await this.instance.methods.minBallotDuration().call()
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,8 @@ class AppMainRouter extends Component {
         contractsStore.getKeysBallotThreshold()
         contractsStore.getProxyBallotThreshold()
         contractsStore.getBallotCancelingThreshold()
-        contractsStore.getBallotsLimits()
+
+        await contractsStore.getBallotsLimits()
 
         await contractsStore.getAllValidatorMetadata()
         await contractsStore.getAllBallots()


### PR DESCRIPTION
- (Mandatory) Description

    These changes fix the text note which is displayed next to the `Finalize` button. The incorrect note `Finalization is available after ballot time is finished or all validators are voted` is shown when the [`minBallotDuration`](https://github.com/poanetwork/poa-network-consensus-contracts/blob/862c6e7b48f7a803e0282f05e90287b70b32af2a/contracts/abstracts/VotingToChange.sol#L95) is not yet expired. In such a case the note should be `Finalization is available after ballot time is finished`.

![image](https://user-images.githubusercontent.com/33550681/58425388-5c1d6b80-80a2-11e9-8944-90eb0ad135d6.png)

- (Mandatory) What is it: (Fix), (Feature), or (Refactor) in Title
(Fix)