### PR TITLE
(Update) Optimize ballot card a bit

### DIFF
--- a/src/components/BallotCard/index.js
+++ b/src/components/BallotCard/index.js
@@ -320,6 +320,10 @@ export class BallotCard extends React.Component {
   @action('validator has already voted')
   getHasAlreadyVoted = async () => {
     const { contractsStore, id, votingType } = this.props
+    if (contractsStore.miningKey === '0x0000000000000000000000000000000000000000') {
+      this.hasAlreadyVoted = false
+      return
+    }
     let _hasAlreadyVoted = false
     try {
       _hasAlreadyVoted = await this.getContract(contractsStore, votingType).hasAlreadyVoted(


### PR DESCRIPTION
This change eliminates the need for an excess calling of [`VotingTo*.hasAlreadyVoted`](https://github.com/poanetwork/poa-network-consensus-contracts/blob/ea84f6127c818450f39ffc00cab68ced60dd9280/contracts/abstracts/VotingTo.sol#L107) function when the current user is not a validator.