### PR TITLE
(Fix) Set exact repo tree for xDai since poa-chain-spec/contracts.json changed

### DIFF
--- a/src/contracts/helpers.js
+++ b/src/contracts/helpers.js
@@ -3,6 +3,9 @@ import messages from '../utils/messages'
 import swal from 'sweetalert2'
 
 function addressesURL(branch) {
+  if (branch === constants.DAI) {
+    branch = 'ce2c77256f0d37fc48baa9b6cab806261d034785'
+  }
   const URL = `https://raw.githubusercontent.com/${constants.organization}/${constants.repoName}/${branch}/${
     constants.addressesSourceFile
   }`
@@ -10,6 +13,9 @@ function addressesURL(branch) {
 }
 
 function ABIURL(branch, contract) {
+  if (branch === constants.DAI) {
+    branch = 'ce2c77256f0d37fc48baa9b6cab806261d034785'
+  }
   const URL = `https://raw.githubusercontent.com/${constants.organization}/${constants.repoName}/${branch}/abis/${
     constants.ABIsSources[contract]
   }`


### PR DESCRIPTION
- (Mandatory) Description
Fixes the issue similar to https://github.com/poanetwork/poa-dapps-validators/issues/120. We replaced https://github.com/poanetwork/poa-chain-spec/blob/dai/contracts.json and https://github.com/poanetwork/poa-chain-spec/tree/dai/abis today in https://github.com/poanetwork/poa-chain-spec/pull/140, but DApp uses the previous versions from this tree: https://github.com/poanetwork/poa-chain-spec/tree/ce2c77256f0d37fc48baa9b6cab806261d034785. This PR sets a patch to use the correct tree for `dai` branch. After POSDAO is activated, the DApp should stop supporting xDai because the current POA consensus contracts will stop to be used on xDai (a PR for removing xDai from the DApp will be opened accordingly).
- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)