### PR TITLE
(Fix) Remove xDai from the list of supported chains

### DIFF
--- a/src/components/Loading/index.js
+++ b/src/components/Loading/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import xDaiLogo from './xdai.svg'
+//import xDaiLogo from './xdai.svg'
 import poaLogo from './core.svg'
 import sokolLogo from './sokol.svg'
 import kovanLogo from './kovan.svg'
@@ -9,7 +9,7 @@ const getLogoSrc = networkBranch => {
     {
       core: poaLogo,
       sokol: sokolLogo,
-      dai: xDaiLogo,
+      //dai: xDaiLogo,
       kovan: kovanLogo
     }[networkBranch] || poaLogo
   )

--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { LogoPOA } from '../LogoPOA'
 import { LogoSokol } from '../LogoSokol'
 import { LogoKovan } from '../LogoKovan'
-import { LogoDai } from '../LogoDai'
+//import { LogoDai } from '../LogoDai'
 import { constants } from '../../utils/constants'
 
 export const Logo = ({ href = null, extraClass = '', networkBranch = '' }) => {
@@ -11,8 +11,8 @@ export const Logo = ({ href = null, extraClass = '', networkBranch = '' }) => {
       return <LogoSokol href={href} extraClass={extraClass} />
     case constants.KOVAN:
       return <LogoKovan href={href} extraClass={extraClass} />
-    case constants.DAI:
-      return <LogoDai href={href} extraClass={extraClass} />
+    //case constants.DAI:
+    //  return <LogoDai href={href} extraClass={extraClass} />
     default:
       return <LogoPOA href={href} extraClass={extraClass} />
   }

--- a/src/contracts/helpers.js
+++ b/src/contracts/helpers.js
@@ -3,9 +3,6 @@ import messages from '../utils/messages'
 import swal from 'sweetalert2'
 
 function addressesURL(branch) {
-  if (branch === constants.DAI) {
-    branch = 'ce2c77256f0d37fc48baa9b6cab806261d034785'
-  }
   const URL = `https://raw.githubusercontent.com/${constants.organization}/${constants.repoName}/${branch}/${
     constants.addressesSourceFile
   }`
@@ -13,9 +10,6 @@ function addressesURL(branch) {
 }
 
 function ABIURL(branch, contract) {
-  if (branch === constants.DAI) {
-    branch = 'ce2c77256f0d37fc48baa9b6cab806261d034785'
-  }
   const URL = `https://raw.githubusercontent.com/${constants.organization}/${constants.repoName}/${branch}/abis/${
     constants.ABIsSources[contract]
   }`

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -53,7 +53,6 @@ constants.navigationData = [
 
 constants.SOKOL = 'sokol'
 constants.CORE = 'core'
-constants.DAI = 'dai'
 constants.KOVAN = 'kovan'
 
 constants.NETWORKS = {
@@ -77,13 +76,6 @@ constants.NETWORKS = {
     RPC: 'https://core.poa.network',
     BRANCH: constants.CORE,
     SORTORDER: 1
-  },
-  '100': {
-    NAME: 'xDai',
-    FULLNAME: 'xDai Stable Chain',
-    RPC: 'https://dai.poa.network',
-    BRANCH: constants.DAI,
-    SORTORDER: 2
   }
 }
 


### PR DESCRIPTION
- (Mandatory) Description
Since we switched the xDai chain to POSDAO consensus, Voting DApp makes no sense for xDai anymore. I removed the chain from the list of supported chains but left commented out its CSS components as they can be used by someone who may want to up the chain from scratch using the instruction https://www.xdaichain.com/for-developers/stable-chain-network-deployment

- (Mandatory) What is it: (Fix), (Feature), or (Refactor) in Title
(Fix)